### PR TITLE
feat: éditeur de paramètres/branding admin + gestion complète des groupes

### DIFF
--- a/apps/frontend/app/actions/groups.ts
+++ b/apps/frontend/app/actions/groups.ts
@@ -1,5 +1,7 @@
 "use server";
 
+// Server actions for groups: CRUD, members, curriculum, invitations, stats.
+
 import { ApiError, apiFetch, apiFetchText } from "@/lib/api";
 import type { CourseSummary, GroupResponse, GroupSummary } from "@/lib/types";
 
@@ -113,7 +115,61 @@ export interface Invitation {
 
 export async function getInvitations(groupId: string, includeRevoked = false): Promise<Invitation[]> {
   const qs = includeRevoked ? "?includeRevoked=true" : "";
-  return (
-    (await apiFetch<Invitation[]>(`/api/v1/groups/${groupId}/invitations${qs}`)) ?? []
-  );
+  try {
+    return (await apiFetch<Invitation[]>(`/api/v1/groups/${groupId}/invitations${qs}`)) ?? [];
+  } catch (e) {
+    if (e instanceof ApiError && (e.status === 403 || e.status === 404)) return [];
+    throw e;
+  }
+}
+
+export async function createGroup(payload: {
+  name: string;
+  slug?: string;
+  startsAt?: string | null;
+  endsAt?: string | null;
+}): Promise<{ ok: boolean; error?: string; group?: GroupResponse }> {
+  try {
+    const g = await apiFetch<GroupResponse>("/api/v1/groups", {
+      method: "POST",
+      body: payload,
+    });
+    return { ok: true, group: g ?? undefined };
+  } catch (e) {
+    return { ok: false, error: e instanceof ApiError ? e.message : undefined };
+  }
+}
+
+export async function updateGroup(
+  id: string,
+  payload: { name?: string; startsAt?: string | null; endsAt?: string | null }
+): Promise<{ ok: boolean; error?: string; group?: GroupResponse }> {
+  try {
+    const g = await apiFetch<GroupResponse>(`/api/v1/groups/${id}`, {
+      method: "PATCH",
+      body: payload,
+    });
+    return { ok: true, group: g ?? undefined };
+  } catch (e) {
+    return { ok: false, error: e instanceof ApiError ? e.message : undefined };
+  }
+}
+
+export async function createInvitation(
+  groupId: string,
+  maxUses: number,
+  expiresAt?: string
+): Promise<{ ok: boolean; error?: string; invitation?: Invitation }> {
+  try {
+    const inv = await apiFetch<Invitation>(
+      `/api/v1/groups/${groupId}/invitations`,
+      {
+        method: "POST",
+        body: { maxUses, ...(expiresAt ? { expiresAt } : {}) },
+      }
+    );
+    return { ok: true, invitation: inv ?? undefined };
+  } catch (e) {
+    return { ok: false, error: e instanceof ApiError ? e.message : undefined };
+  }
 }

--- a/apps/frontend/app/actions/instance.ts
+++ b/apps/frontend/app/actions/instance.ts
@@ -1,24 +1,60 @@
-import "server-only";
+"use server";
 
 /**
- * Fetch instance branding
-*/
+ * Instance branding — backed by GET/PATCH /api/v1/settings/branding.
+ * Branding read is public (consumed by the landing before login); writes are Admin+.
+ */
 
-import { apiFetch } from "@/lib/api";
-import { DEFAULT_INSTANCE } from "@/lib/instance";
-import type { InstanceBranding } from "@/lib/types";
+import { updateTag } from "next/cache";
 
-// TODO replace to settings
+import { ApiError, apiFetch } from "@/lib/api";
+import { DEFAULT_INSTANCE, DEFAULT_THEME_TOKENS } from "@/lib/instance";
+import type { InstanceBranding, UpdateBrandingPayload } from "@/lib/types";
+
+const BRANDING_TAG = "instance-branding";
+
+/** Fill any field the backend might omit so consumers always get a complete object. */
+function withDefaults(data: Partial<InstanceBranding> | null): InstanceBranding {
+  if (!data) return DEFAULT_INSTANCE;
+  return {
+    ...DEFAULT_INSTANCE,
+    ...data,
+    theme: {
+      light: { ...DEFAULT_THEME_TOKENS.light, ...data.theme?.light },
+      dark: { ...DEFAULT_THEME_TOKENS.dark, ...data.theme?.dark },
+    },
+  };
+}
+
 export async function getInstanceBranding(): Promise<InstanceBranding> {
   try {
-    const data = await apiFetch<InstanceBranding>("/api/v1/instance/branding", {
+    const data = await apiFetch<InstanceBranding>("/api/v1/settings/branding", {
       method: "GET",
       withAuth: false,
-      next: { revalidate: 60 },
+      next: { revalidate: 60, tags: [BRANDING_TAG] },
     });
-    return data ?? DEFAULT_INSTANCE;
+    return withDefaults(data ?? null);
   } catch {
     // Frontend static fallback
     return DEFAULT_INSTANCE;
+  }
+}
+
+export async function updateBranding(
+  payload: UpdateBrandingPayload
+): Promise<{ ok: boolean; error?: string; data?: InstanceBranding }> {
+  try {
+    const data = await apiFetch<InstanceBranding>("/api/v1/settings/branding", {
+      method: "PATCH",
+      body: payload,
+    });
+    // Bust the cached public branding fetch so reloads show fresh values
+    // (read-your-own-writes within this request and on subsequent reloads).
+    updateTag(BRANDING_TAG);
+    return { ok: true, data: data ? withDefaults(data) : undefined };
+  } catch (e) {
+    if (e instanceof ApiError) return { ok: false, error: e.message };
+    if (e instanceof Error) return { ok: false, error: e.message };
+    return { ok: false, error: undefined };
   }
 }

--- a/apps/frontend/app/actions/settings.ts
+++ b/apps/frontend/app/actions/settings.ts
@@ -1,11 +1,11 @@
 "use server";
 
 /**
- * Instance settings
+ * Platform settings — backed by GET/PATCH /api/v1/settings (Admin+).
  */
 
 import { ApiError, apiFetch } from "@/lib/api";
-import type { InstanceSettings } from "@/lib/types";
+import type { InstanceSettings, UpdateSettingsPayload } from "@/lib/types";
 
 export async function getSettings(): Promise<InstanceSettings | null> {
   try {
@@ -16,9 +16,9 @@ export async function getSettings(): Promise<InstanceSettings | null> {
   }
 }
 
-export async function updateSettings(payload: {
-  maxBlocksPerPage: number;
-}): Promise<{ ok: boolean; error?: string; data?: InstanceSettings }> {
+export async function updateSettings(
+  payload: UpdateSettingsPayload
+): Promise<{ ok: boolean; error?: string; data?: InstanceSettings }> {
   try {
     const data = await apiFetch<InstanceSettings>("/api/v1/settings", {
       method: "PATCH",

--- a/apps/frontend/app/admin/groups/[id]/page.tsx
+++ b/apps/frontend/app/admin/groups/[id]/page.tsx
@@ -1,0 +1,96 @@
+// Group hub — quick links to members/curriculum and the invitations panel.
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import { getGroup, getInvitations, getMyGroups } from "@/app/actions/groups";
+import { AdminBreadcrumb, AdminShell } from "@/components/admin/admin-shell";
+import { InvitationsPanel } from "@/components/admin/invitations-panel";
+import { requireRole } from "@/components/admin/role-guard";
+import { PageHeader } from "@/components/course/page-header";
+import { GlassCard, GlassCardContent } from "@/components/ui/glass-card";
+import { isAdmin } from "@/lib/roles";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata: Metadata = { title: "Groupe" };
+
+export default async function GroupHubPage({ params }: PageProps) {
+  const me = await requireRole("TEACHER");
+  const { id } = await params;
+  const admin = isAdmin(me.role);
+  const t = await getTranslations("admin.groups");
+
+  let groupName: string | null = null;
+  if (admin) {
+    const g = await getGroup(id);
+    groupName = g?.name ?? null;
+  } else {
+    const mine = await getMyGroups();
+    groupName = mine.find((g) => g.id === id)?.name ?? null;
+  }
+  if (!groupName) notFound();
+
+  const invitations = await getInvitations(id);
+
+  return (
+    <AdminShell>
+      <AdminBreadcrumb
+        items={[
+          { label: "Admin", href: "/admin" },
+          { label: t("title"), href: "/admin/groups" },
+          { label: groupName },
+        ]}
+      />
+      <PageHeader
+        kicker={t("hub.kicker", { name: groupName })}
+        title={groupName}
+        className="mb-8"
+      />
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Link href={`/admin/groups/${id}/members`} className="block">
+          <GlassCard variant="default" interactive className="h-full">
+            <GlassCardContent className="flex flex-col gap-1 p-5">
+              <p className="font-semibold text-text">{t("members")}</p>
+              <p className="text-sm text-text-soft">{t("hub.membersDesc")}</p>
+            </GlassCardContent>
+          </GlassCard>
+        </Link>
+
+        <Link href={`/admin/groups/${id}/curriculum`} className="block">
+          <GlassCard variant="default" interactive className="h-full">
+            <GlassCardContent className="flex flex-col gap-1 p-5">
+              <p className="font-semibold text-text">{t("curriculum")}</p>
+              <p className="text-sm text-text-soft">{t("hub.curriculumDesc")}</p>
+            </GlassCardContent>
+          </GlassCard>
+        </Link>
+      </div>
+
+      <InvitationsPanel
+        groupId={id}
+        initialInvitations={invitations}
+        labels={{
+          invitationsTitle: t("hub.invitationsTitle"),
+          invitationsDesc: t("hub.invitationsDesc"),
+          newInvitation: t("hub.newInvitation"),
+          invitationFormMaxUses: t("hub.invitationFormMaxUses"),
+          invitationFormExpiresAt: t("hub.invitationFormExpiresAt"),
+          invitationFormCreate: t("hub.invitationFormCreate"),
+          code: t("hub.code"),
+          uses: t("hub.uses"),
+          expires: t("hub.expires"),
+          noExpiry: t("hub.noExpiry"),
+          noInvitations: t("hub.noInvitations"),
+          copyCode: t("hub.copyCode"),
+          createError: t("hub.createError"),
+        }}
+      />
+    </AdminShell>
+  );
+}

--- a/apps/frontend/app/admin/groups/page.tsx
+++ b/apps/frontend/app/admin/groups/page.tsx
@@ -1,0 +1,70 @@
+// Groups list page — all groups for admins, own groups otherwise.
+
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+import { getAllGroups, getMyGroups } from "@/app/actions/groups";
+import { AdminBreadcrumb, AdminShell } from "@/components/admin/admin-shell";
+import { CreateGroupTrigger } from "@/components/admin/create-group-trigger";
+import { GroupsGrid } from "@/components/admin/groups-grid";
+import { requireRole } from "@/components/admin/role-guard";
+import { PageHeader } from "@/components/course/page-header";
+import { isAdmin } from "@/lib/roles";
+
+export const metadata: Metadata = { title: "Groupes" };
+
+export default async function GroupsPage() {
+  const me = await requireRole("TEACHER");
+  const admin = isAdmin(me.role);
+  const t = await getTranslations("admin.groups");
+
+  const groups = admin ? await getAllGroups() : await getMyGroups();
+
+  return (
+    <AdminShell>
+      <AdminBreadcrumb
+        items={[{ label: "Admin", href: "/admin" }, { label: t("title") }]}
+      />
+      <PageHeader
+        kicker={t("kicker")}
+        title={t("title")}
+        description={t("description")}
+        actions={
+          admin ? (
+            <CreateGroupTrigger
+              newGroup={t("newGroup")}
+              form={{
+                title: t("form.title"),
+                name: t("form.name"),
+                namePlaceholder: t("form.namePlaceholder"),
+                slug: t("form.slug"),
+                slugPlaceholder: t("form.slugPlaceholder"),
+                slugHelper: t("form.slugHelper"),
+                startsAt: t("form.startsAt"),
+                endsAt: t("form.endsAt"),
+                create: t("form.create"),
+                cancel: t("form.cancel"),
+                error: t("form.error"),
+              }}
+            />
+          ) : null
+        }
+        className="mb-8"
+      />
+      <GroupsGrid
+        groups={groups}
+        isAdmin={admin}
+        labels={{
+          members: t("members"),
+          curriculum: t("curriculum"),
+          deleteConfirm: t("deleteConfirm"),
+          deleteBtn: t("deleteBtn"),
+          deleteError: t("deleteError"),
+          dateSince: t("dateSince"),
+          dateUntil: t("dateUntil"),
+          empty: t("empty"),
+        }}
+      />
+    </AdminShell>
+  );
+}

--- a/apps/frontend/app/admin/settings/page.tsx
+++ b/apps/frontend/app/admin/settings/page.tsx
@@ -1,31 +1,63 @@
+// Admin settings page — loads branding + platform settings, renders the editor.
+
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
+import { getInstanceBranding } from "@/app/actions/instance";
 import { getSettings } from "@/app/actions/settings";
 import { AdminBreadcrumb, AdminShell } from "@/components/admin/admin-shell";
 import { requireRole } from "@/components/admin/role-guard";
 import { SettingsForm } from "@/components/admin/settings-form";
+import { SettingsWorkspace } from "@/components/admin/settings/settings-workspace";
 import { PageHeader } from "@/components/course/page-header";
 import { GlassCard, GlassCardContent } from "@/components/ui/glass-card";
+import type { InstanceSettings } from "@/lib/types";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("adminSettings");
   return { title: t("title") };
 }
 
+/** Safe defaults if the backend hasn't persisted settings yet. */
+const FALLBACK_SETTINGS: InstanceSettings = {
+  signupOpen: true,
+  mediaUserQuotaMb: 100,
+  mediaInstanceQuotaMb: 5000,
+  aiApiUrl: "",
+  aiModel: "",
+  aiMaxTokens: 4096,
+  aiTemperature: 0.7,
+  aiApiKeySet: false,
+};
+
 export default async function AdminSettingsPage() {
   await requireRole("ADMIN");
   const t = await getTranslations("adminSettings");
-  const settings = await getSettings();
+
+  const [branding, settings] = await Promise.all([
+    getInstanceBranding(),
+    getSettings(),
+  ]);
 
   return (
     <AdminShell>
       <AdminBreadcrumb
         items={[{ label: "Admin", href: "/admin" }, { label: t("title") }]}
       />
-      <PageHeader kicker={t("kicker")} title={t("title")} description={t("description")} className="mb-8" />
+      <PageHeader
+        kicker={t("kicker")}
+        title={t("title")}
+        description={t("description")}
+        className="mb-8"
+      />
 
-      <GlassCard variant="default">
+      <SettingsWorkspace
+        initialBranding={branding}
+        initialSettings={settings ?? FALLBACK_SETTINGS}
+      />
+
+      {/* Course builder settings (kept from the existing settings page). */}
+      <GlassCard variant="default" className="mt-6">
         <GlassCardContent className="p-6">
           <h2 className="mb-4 font-display text-[1.2rem] text-text">
             {t("courseBuilderSection")}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -8,7 +8,28 @@ import { getInstanceBranding } from "@/app/actions/instance";
 import { AuthProvider } from "@/components/auth-provider";
 import { BrandingProvider } from "@/components/branding-provider";
 import { MeshBackground } from "@/components/ui/mesh-background";
+import { themeTokensToVars } from "@/lib/branding-css";
 import { SITE_URL } from "@/lib/site";
+import type { InstanceBranding } from "@/lib/types";
+
+/**
+ * Branding color tokens injected in <head> so saved branding overrides the
+ * globals.css defaults. `html[data-theme]` selectors win over `:root`, and the
+ * light/dark split keeps both modes correct.
+ */
+function brandingStyle(branding: InstanceBranding): string {
+  const vars = (o: Record<string, string>) =>
+    Object.entries(o)
+      .map(([k, v]) => `${k}:${v};`)
+      .join("");
+  const soft = (pct: string) =>
+    `color-mix(in srgb, ${branding.accent} ${pct}, transparent)`;
+  return [
+    `html[data-theme]{--color-accent-raw:${branding.accent};}`,
+    `html[data-theme="light"]{${vars(themeTokensToVars(branding.theme.light))}--color-accent-soft-raw:${soft("16%")};}`,
+    `html[data-theme="dark"]{${vars(themeTokensToVars(branding.theme.dark))}--color-accent-soft-raw:${soft("24%")};}`,
+  ].join("");
+}
 
 import "./globals.css";
 
@@ -27,7 +48,7 @@ const instrumentSerif = Instrument_Serif({
   display: "swap",
 });
 
-export const metadata: Metadata = {
+const baseMetadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
     default: "Codestar — Open-source e-learning, hosted by you",
@@ -76,6 +97,15 @@ export const metadata: Metadata = {
   icons: { icon: "/favicon.ico" },
 };
 
+// Favicon (and title) follow the saved branding.
+export async function generateMetadata(): Promise<Metadata> {
+  const branding = await getInstanceBranding();
+  return {
+    ...baseMetadata,
+    icons: { icon: branding.favicon ?? "/favicon.ico" },
+  };
+}
+
 export const viewport: Viewport = {
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#f4f6fb" },
@@ -112,13 +142,12 @@ export default async function RootLayout({
   return (
     <html
       lang={locale}
+      data-theme="light"
       className={`${outfit.variable} ${instrumentSerif.variable} h-full antialiased`}
-      style={
-        {
-          "--color-accent-raw": branding.accent,
-        } as React.CSSProperties
-      }
     >
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: brandingStyle(branding) }} />
+      </head>
       <body className="min-h-full flex flex-col bg-bg-base text-text font-sans">
         <script
           type="application/ld+json"

--- a/apps/frontend/components/admin/ai-generator-form.tsx
+++ b/apps/frontend/components/admin/ai-generator-form.tsx
@@ -345,7 +345,7 @@ function PromptHelpPopover() {
             ))}
           </ul>
           <p className="mt-3 border-t border-white/10 pt-3 text-[11px] text-muted">
-            Exemple : <em className="text-text-soft">"Introduction à Docker pour des lycéens en terminale NSI, ton accessible, avec des analogies du quotidien"</em>
+            Exemple : <em className="text-text-soft">&quot;Introduction à Docker pour des lycéens en terminale NSI, ton accessible, avec des analogies du quotidien&quot;</em>
           </p>
         </div>
       )}

--- a/apps/frontend/components/admin/create-group-modal.tsx
+++ b/apps/frontend/components/admin/create-group-modal.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+// Modal form to create a group (name, slug, date range).
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { createGroup } from "@/app/actions/groups";
+import { GlassButton } from "@/components/ui/glass-button";
+import { GlassField, GlassInput } from "@/components/ui/glass-input";
+
+export interface CreateGroupModalLabels {
+  title: string;
+  name: string;
+  namePlaceholder: string;
+  slug: string;
+  slugPlaceholder: string;
+  slugHelper: string;
+  startsAt: string;
+  endsAt: string;
+  create: string;
+  cancel: string;
+  error: string;
+}
+
+interface CreateGroupModalProps {
+  open: boolean;
+  onClose: () => void;
+  labels: CreateGroupModalLabels;
+}
+
+export function CreateGroupModal({ open, onClose, labels }: CreateGroupModalProps) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+  const [error, setError] = useState("");
+  const formRef = useRef<HTMLFormElement>(null);
+
+  if (!open) return null;
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const fd = new FormData(form);
+    const name = (fd.get("name") as string).trim();
+    const slug = (fd.get("slug") as string).trim() || undefined;
+    const startsAt = (fd.get("startsAt") as string) || null;
+    const endsAt = (fd.get("endsAt") as string) || null;
+
+    setError("");
+    start(async () => {
+      const res = await createGroup({ name, slug, startsAt, endsAt });
+      if (res.ok) {
+        router.refresh();
+        onClose();
+      } else {
+        setError(res.error ?? labels.error);
+      }
+    });
+  }
+
+  function handleClose() {
+    setError("");
+    onClose();
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[color:var(--glass-bg)] p-6 shadow-2xl">
+        <h2 className="mb-5 text-lg font-semibold text-text">
+          {labels.title}
+        </h2>
+
+        <form ref={formRef} onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <GlassField label={labels.name} htmlFor="name">
+            <GlassInput
+              id="name"
+              name="name"
+              placeholder={labels.namePlaceholder}
+              required
+              autoFocus
+            />
+          </GlassField>
+
+          <GlassField label={labels.slug} htmlFor="slug" helper={labels.slugHelper}>
+            <GlassInput
+              id="slug"
+              name="slug"
+              placeholder={labels.slugPlaceholder}
+              pattern="^[a-z0-9](?:[a-z0-9-]{0,78}[a-z0-9])?$"
+            />
+          </GlassField>
+
+          <div className="grid grid-cols-2 gap-3">
+            <GlassField label={labels.startsAt} htmlFor="startsAt">
+              <GlassInput id="startsAt" name="startsAt" type="date" />
+            </GlassField>
+            <GlassField label={labels.endsAt} htmlFor="endsAt">
+              <GlassInput id="endsAt" name="endsAt" type="date" />
+            </GlassField>
+          </div>
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          <div className="mt-2 flex justify-end gap-2">
+            <GlassButton
+              type="button"
+              variant="ghost"
+              onClick={handleClose}
+              disabled={pending}
+            >
+              {labels.cancel}
+            </GlassButton>
+            <GlassButton type="submit" variant="primary" disabled={pending}>
+              {pending ? "…" : labels.create}
+            </GlassButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/admin/create-group-trigger.tsx
+++ b/apps/frontend/components/admin/create-group-trigger.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+// Button that opens the create-group modal.
+
+import { useState } from "react";
+
+import { CreateGroupModal, type CreateGroupModalLabels } from "@/components/admin/create-group-modal";
+import { GlassButton } from "@/components/ui/glass-button";
+
+interface CreateGroupTriggerProps {
+  newGroup: string;
+  form: CreateGroupModalLabels;
+}
+
+export function CreateGroupTrigger({ newGroup, form }: CreateGroupTriggerProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <GlassButton variant="primary" onClick={() => setOpen(true)}>
+        {newGroup}
+      </GlassButton>
+      <CreateGroupModal open={open} onClose={() => setOpen(false)} labels={form} />
+    </>
+  );
+}

--- a/apps/frontend/components/admin/groups-grid.tsx
+++ b/apps/frontend/components/admin/groups-grid.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+// Groups grid — one card per group with member/curriculum links and admin delete.
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useLocale } from "next-intl";
+import { useState, useTransition } from "react";
+
+import { deleteGroup } from "@/app/actions/groups";
+import { GlassCard, GlassCardContent } from "@/components/ui/glass-card";
+import { GlassChip } from "@/components/ui/glass-chip";
+import { ArrowRightIcon, BookIcon, TrashIcon, UsersIcon } from "@/components/ui/icons";
+
+interface GroupItem {
+  id: string;
+  name: string;
+  slug: string;
+  startsAt: string | null;
+  endsAt: string | null;
+}
+
+interface Labels {
+  members: string;
+  curriculum: string;
+  deleteConfirm: string;
+  deleteBtn: string;
+  deleteError: string;
+  dateSince: string;
+  dateUntil: string;
+  empty: string;
+}
+
+interface GroupsGridProps {
+  groups: GroupItem[];
+  isAdmin: boolean;
+  labels: Labels;
+}
+
+interface GroupCardProps {
+  group: GroupItem;
+  isAdmin: boolean;
+  labels: Labels;
+}
+
+const PALETTE = [
+  { bg: "rgba(109,40,217,0.22)", text: "#a78bfa" },
+  { bg: "rgba(3,105,161,0.22)", text: "#38bdf8" },
+  { bg: "rgba(5,150,105,0.22)", text: "#34d399" },
+  { bg: "rgba(217,119,6,0.22)", text: "#fbbf24" },
+  { bg: "rgba(190,24,93,0.22)", text: "#f472b6" },
+  { bg: "rgba(126,34,206,0.22)", text: "#d8b4fe" },
+];
+
+function slugPalette(slug: string) {
+  let h = 0;
+  for (const c of slug) h = (h * 31 + c.charCodeAt(0)) >>> 0;
+  return PALETTE[h % PALETTE.length];
+}
+
+// Builds a localized "since/until" range from optional start/end dates.
+function formatDateRange(
+  startsAt: string | null,
+  endsAt: string | null,
+  locale: string,
+  labels: Labels
+) {
+  const fmt = (d: string) =>
+    new Date(d).toLocaleDateString(locale, { month: "short", year: "numeric" });
+  if (startsAt && endsAt) return `${fmt(startsAt)} → ${fmt(endsAt)}`;
+  if (startsAt) return labels.dateSince.replace("{date}", fmt(startsAt));
+  if (endsAt) return labels.dateUntil.replace("{date}", fmt(endsAt));
+  return null;
+}
+
+function GroupCard({ group: g, isAdmin, labels }: GroupCardProps) {
+  const router = useRouter();
+  const locale = useLocale();
+  const [pending, start] = useTransition();
+  const [error, setError] = useState("");
+  const palette = slugPalette(g.slug);
+  const dateLabel = formatDateRange(g.startsAt, g.endsAt, locale, labels);
+
+  function handleDelete() {
+    if (!confirm(`${labels.deleteConfirm}\n\n"${g.name}"`)) return;
+    setError("");
+    start(async () => {
+      const res = await deleteGroup(g.id);
+      if (!res.ok) {
+        setError(res.error ?? labels.deleteError);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <GlassCard variant="default">
+      <GlassCardContent className="p-0">
+        {/* Header */}
+        <div className="flex items-start gap-3 p-4 pb-3">
+          <div
+            className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-sm font-bold uppercase"
+            style={{ background: palette.bg, color: palette.text }}
+          >
+            {g.name[0]}
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-semibold leading-snug text-text">{g.name}</p>
+            <p className="font-mono text-[0.7rem] text-text-soft">/{g.slug}</p>
+          </div>
+
+          {isAdmin && (
+            <button
+              type="button"
+              disabled={pending}
+              onClick={handleDelete}
+              className="mt-0.5 shrink-0 rounded-lg p-1.5 text-text-soft opacity-50 transition-all hover:bg-red-500/15 hover:text-red-400 hover:opacity-100 disabled:opacity-30"
+              title={labels.deleteBtn}
+            >
+              <TrashIcon size={15} />
+            </button>
+          )}
+        </div>
+
+        {dateLabel && (
+          <div className="px-4 pb-3">
+            <GlassChip size="sm">{dateLabel}</GlassChip>
+          </div>
+        )}
+
+        {error && <p className="px-4 pb-2 text-xs text-red-400">{error}</p>}
+
+        <div className="mx-4 border-t border-[color:var(--glass-border)]" />
+
+        <Link
+          href={`/admin/groups/${g.id}/members`}
+          className="flex items-center gap-3 px-4 py-3 text-sm text-text-soft transition-colors hover:bg-[color:var(--glass-bg)] hover:text-text"
+        >
+          <UsersIcon size={15} className="shrink-0" />
+          <span className="flex-1">{labels.members}</span>
+          <ArrowRightIcon size={14} className="opacity-40" />
+        </Link>
+
+        <div className="mx-4 border-t border-[color:var(--glass-border)]" />
+
+        <Link
+          href={`/admin/groups/${g.id}/curriculum`}
+          className="flex items-center gap-3 rounded-b-[var(--r-lg)] px-4 py-3 text-sm text-text-soft transition-colors hover:bg-[color:var(--glass-bg)] hover:text-text"
+        >
+          <BookIcon size={15} className="shrink-0" />
+          <span className="flex-1">{labels.curriculum}</span>
+          <ArrowRightIcon size={14} className="opacity-40" />
+        </Link>
+      </GlassCardContent>
+    </GlassCard>
+  );
+}
+
+export function GroupsGrid({ groups, isAdmin, labels }: GroupsGridProps) {
+  if (groups.length === 0) {
+    return <p className="mt-8 text-center text-text-soft">{labels.empty}</p>;
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {groups.map((g) => (
+        <GroupCard key={g.id} group={g} isAdmin={isAdmin} labels={labels} />
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/components/admin/invitations-panel.tsx
+++ b/apps/frontend/components/admin/invitations-panel.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+// Invitation codes panel — list plus a create form with optimistic insert.
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { createInvitation, type Invitation } from "@/app/actions/groups";
+import { GlassButton } from "@/components/ui/glass-button";
+import { GlassCard, GlassCardContent } from "@/components/ui/glass-card";
+import { GlassField, GlassInput } from "@/components/ui/glass-input";
+
+interface Labels {
+  invitationsTitle: string;
+  invitationsDesc: string;
+  newInvitation: string;
+  invitationFormMaxUses: string;
+  invitationFormExpiresAt: string;
+  invitationFormCreate: string;
+  code: string;
+  uses: string;
+  expires: string;
+  noExpiry: string;
+  noInvitations: string;
+  copyCode: string;
+  createError: string;
+}
+
+interface InvitationsPanelProps {
+  groupId: string;
+  initialInvitations: Invitation[];
+  labels: Labels;
+}
+
+export function InvitationsPanel({
+  groupId,
+  initialInvitations,
+  labels,
+}: InvitationsPanelProps) {
+  const router = useRouter();
+  const [pending, start] = useTransition();
+  const [showForm, setShowForm] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState<string | null>(null);
+  // Local copy for optimistic updates
+  const [invitations, setInvitations] = useState<Invitation[]>(initialInvitations);
+
+  function handleCopy(code: string) {
+    navigator.clipboard.writeText(code).then(() => {
+      setCopied(code);
+      setTimeout(() => setCopied(null), 2000);
+    }).catch(() => {
+      // Fallback for non-secure contexts
+      setCopied(code);
+      setTimeout(() => setCopied(null), 2000);
+    });
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const fd = new FormData(form);
+    const maxUses = parseInt(fd.get("maxUses") as string, 10) || 1;
+    const rawExpiry = fd.get("expiresAt") as string;
+    const expiresAt = rawExpiry ? new Date(rawExpiry).toISOString() : undefined;
+
+    setError("");
+    start(async () => {
+      const res = await createInvitation(groupId, maxUses, expiresAt);
+      if (res.ok && res.invitation) {
+        setInvitations((prev) => [res.invitation!, ...prev]);
+        setShowForm(false);
+        form.reset();
+        router.refresh();
+      } else {
+        setError(res.error ?? labels.createError);
+      }
+    });
+  }
+
+  return (
+    <section className="mt-10">
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="font-semibold text-text">{labels.invitationsTitle}</h2>
+          <p className="text-sm text-text-soft">{labels.invitationsDesc}</p>
+        </div>
+        <GlassButton
+          variant="outline"
+          size="sm"
+          onClick={() => setShowForm((v) => !v)}
+          className="shrink-0"
+        >
+          {labels.newInvitation}
+        </GlassButton>
+      </div>
+
+      {showForm && (
+        <GlassCard variant="plain" className="mb-4">
+          <GlassCardContent className="p-4">
+            <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-3">
+              <GlassField
+                label={labels.invitationFormMaxUses}
+                htmlFor="maxUses"
+                className="w-32"
+              >
+                <GlassInput
+                  id="maxUses"
+                  name="maxUses"
+                  type="number"
+                  defaultValue={1}
+                  min={1}
+                  max={1000}
+                />
+              </GlassField>
+              <GlassField
+                label={labels.invitationFormExpiresAt}
+                htmlFor="expiresAt"
+                className="w-56"
+              >
+                <GlassInput
+                  id="expiresAt"
+                  name="expiresAt"
+                  type="datetime-local"
+                />
+              </GlassField>
+              <GlassButton
+                type="submit"
+                variant="primary"
+                size="sm"
+                disabled={pending}
+              >
+                {pending ? "…" : labels.invitationFormCreate}
+              </GlassButton>
+            </form>
+            {error && <p className="mt-2 text-sm text-red-400">{error}</p>}
+          </GlassCardContent>
+        </GlassCard>
+      )}
+
+      {invitations.length === 0 ? (
+        <p className="text-sm text-text-soft">{labels.noInvitations}</p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {invitations.map((inv) => (
+            <GlassCard key={inv.id} variant="plain">
+              <GlassCardContent className="flex items-center justify-between gap-4 px-4 py-3">
+                <div className="flex flex-col gap-0.5">
+                  <span className="font-mono text-sm font-medium text-text">
+                    {inv.code}
+                  </span>
+                  <span className="text-xs text-text-soft">
+                    {labels.uses
+                      .replace("{used}", String(inv.usedCount))
+                      .replace("{max}", String(inv.maxUses))}
+                    {" · "}
+                    {inv.expiresAt
+                      ? labels.expires.replace(
+                          "{date}",
+                          new Date(inv.expiresAt).toLocaleDateString()
+                        )
+                      : labels.noExpiry}
+                  </span>
+                </div>
+                <GlassButton
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleCopy(inv.code)}
+                >
+                  {copied === inv.code ? "✓" : labels.copyCode}
+                </GlassButton>
+              </GlassCardContent>
+            </GlassCard>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/components/admin/settings/settings-sections.tsx
+++ b/apps/frontend/components/admin/settings/settings-sections.tsx
@@ -1,0 +1,582 @@
+"use client";
+
+// Settings sections: identity, theme, hero/SEO, access, media, AI.
+
+import * as React from "react";
+import { useTranslations } from "next-intl";
+
+import { ImageUploader } from "@/components/block-kinds/image-uploader";
+import { BrandMark } from "@/components/brand-mark";
+import {
+  ColorField,
+  GlassToggle,
+  RangeField,
+} from "@/components/ui/glass-controls";
+import {
+  GlassField,
+  GlassInput,
+  GlassSelect,
+  GlassTextarea,
+} from "@/components/ui/glass-input";
+import { GlassChip } from "@/components/ui/glass-chip";
+import { ImageIcon, KeyIcon } from "@/components/ui/icons";
+import { FONT_PRESETS } from "@/lib/fonts";
+import type {
+  InstanceBranding,
+  InstanceSettings,
+  ThemeTokens,
+} from "@/lib/types";
+
+type ThemeMode = "light" | "dark";
+
+const LOGO_PRESETS = ["star", "alpha", "flame", "hash"] as const;
+const LOCALES = ["en", "fr"] as const;
+
+export interface BrandingSectionProps {
+  branding: InstanceBranding;
+  patch: (partial: Partial<InstanceBranding>) => void;
+}
+
+export interface SettingsSectionProps {
+  settings: InstanceSettings;
+  patch: (partial: Partial<InstanceSettings>) => void;
+}
+
+/* ===================== Identity ===================== */
+
+/** Small two-option segmented control. */
+function Segmented<T extends string>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+}: {
+  value: T;
+  options: { id: T; label: string }[];
+  onChange: (v: T) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className="inline-flex rounded-full border border-[color:var(--glass-border)] bg-[color:var(--glass-bg)] p-0.5"
+    >
+      {options.map((o) => (
+        <button
+          key={o.id}
+          type="button"
+          aria-pressed={value === o.id}
+          onClick={() => onChange(o.id)}
+          className={
+            "cursor-pointer rounded-full px-3.5 py-1.5 text-[0.8rem] font-medium transition-colors duration-150 " +
+            (value === o.id
+              ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-fg)]"
+              : "text-text-soft hover:text-text")
+          }
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function LogoField({ branding, patch }: BrandingSectionProps) {
+  const t = useTranslations("adminSettings.identity");
+  const isImage = branding.logo.kind !== "preset";
+  const [mode, setMode] = React.useState<"preset" | "image">(
+    isImage ? "image" : "preset"
+  );
+
+  return (
+    <div className="w-full">
+      <div className="mb-1.5 flex items-center justify-between gap-3">
+        <span className="text-[0.8rem] font-medium text-text-soft">
+          {t("logo")}
+        </span>
+        <Segmented
+          ariaLabel={t("logo")}
+          value={mode}
+          onChange={(m) => {
+            setMode(m);
+            // Switching back to preset restores a default glyph.
+            if (m === "preset" && branding.logo.kind !== "preset") {
+              patch({ logo: { kind: "preset", value: "star" } });
+            }
+          }}
+          options={[
+            { id: "preset", label: t("logoMode.preset") },
+            { id: "image", label: t("logoMode.image") },
+          ]}
+        />
+      </div>
+
+      {mode === "preset" ? (
+        <GlassSelect
+          id="b-logo"
+          value={branding.logo.kind === "preset" ? branding.logo.value : "star"}
+          onChange={(e) =>
+            patch({ logo: { kind: "preset", value: e.target.value } })
+          }
+        >
+          {LOGO_PRESETS.map((p) => (
+            <option key={p} value={p}>
+              {t(`logoPreset.${p}`)}
+            </option>
+          ))}
+        </GlassSelect>
+      ) : (
+        <div className="flex items-center gap-3">
+          <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-[var(--r-sm)] border border-[color:var(--glass-border)] bg-[color:var(--glass-bg-strong)]">
+            <BrandMark size={32} logo={branding.logo} accent={branding.accent} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <ImageUploader
+              label={isImage ? t("logoReplace") : t("logoUpload")}
+              errorLabel={t("uploadError")}
+              onUploaded={(url) => patch({ logo: { kind: "upload", value: url } })}
+            />
+          </div>
+        </div>
+      )}
+      <p className="mt-1.5 text-[0.78rem] text-muted">{t("logoHelper")}</p>
+    </div>
+  );
+}
+
+export function IdentitySection({ branding, patch }: BrandingSectionProps) {
+  const t = useTranslations("adminSettings.identity");
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-5 sm:grid-cols-2">
+        <GlassField label={t("name")} htmlFor="b-name">
+          <GlassInput
+            id="b-name"
+            value={branding.name}
+            onChange={(e) => patch({ name: e.target.value })}
+          />
+        </GlassField>
+        <GlassField label={t("tagline")} htmlFor="b-tagline">
+          <GlassInput
+            id="b-tagline"
+            value={branding.tagline}
+            onChange={(e) => patch({ tagline: e.target.value })}
+          />
+        </GlassField>
+      </div>
+
+      <div className="grid gap-5 sm:grid-cols-2">
+        <LogoField branding={branding} patch={patch} />
+        <GlassField label={t("locale")} htmlFor="b-locale">
+          <GlassSelect
+            id="b-locale"
+            value={branding.locale}
+            onChange={(e) => patch({ locale: e.target.value })}
+          >
+            {LOCALES.map((l) => (
+              <option key={l} value={l}>
+                {t(`localeOption.${l}`)}
+              </option>
+            ))}
+          </GlassSelect>
+        </GlassField>
+      </div>
+
+      <div className="grid gap-5 sm:grid-cols-2">
+        <ColorField
+          id="b-accent"
+          label={t("accent")}
+          value={branding.accent}
+          onChange={(hex) => patch({ accent: hex })}
+          helper={t("accentHelper")}
+        />
+        <GlassField label={t("font")} htmlFor="b-font" helper={t("fontHelper")}>
+          <GlassSelect
+            id="b-font"
+            value={branding.fontPreset}
+            onChange={(e) => patch({ fontPreset: e.target.value })}
+          >
+            {FONT_PRESETS.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))}
+          </GlassSelect>
+        </GlassField>
+      </div>
+    </div>
+  );
+}
+
+/* ===================== Theme ===================== */
+
+const TOKEN_GROUPS: {
+  group: "backgrounds" | "text" | "status";
+  keys: (keyof ThemeTokens)[];
+}[] = [
+  { group: "backgrounds", keys: ["bgBase", "bgMesh1", "bgMesh2", "bgMesh3"] },
+  { group: "text", keys: ["text", "textSoft", "muted"] },
+  { group: "status", keys: ["success", "warning", "danger", "green", "tip"] },
+];
+
+export interface ThemeSectionProps extends BrandingSectionProps {
+  mode: ThemeMode;
+  onMode: (m: ThemeMode) => void;
+}
+
+export function ThemeSection({
+  branding,
+  patch,
+  mode,
+  onMode,
+}: ThemeSectionProps) {
+  const t = useTranslations("adminSettings.theme");
+  const tokens = branding.theme[mode];
+
+  function setToken(key: keyof ThemeTokens, value: string) {
+    patch({
+      theme: {
+        ...branding.theme,
+        [mode]: { ...branding.theme[mode], [key]: value },
+      },
+    });
+  }
+
+  return (
+    <div className="space-y-5">
+      <div
+        role="group"
+        aria-label={t("modeSwitch")}
+        className="inline-flex rounded-full border border-[color:var(--glass-border)] bg-[color:var(--glass-bg)] p-0.5"
+      >
+        {(["light", "dark"] as const).map((m) => (
+          <button
+            key={m}
+            type="button"
+            aria-pressed={mode === m}
+            onClick={() => onMode(m)}
+            className={
+              "cursor-pointer rounded-full px-4 py-1.5 text-[0.8rem] font-medium capitalize transition-colors duration-150 " +
+              (mode === m
+                ? "bg-[color:var(--color-accent)] text-[color:var(--color-accent-fg)]"
+                : "text-text-soft hover:text-text")
+            }
+          >
+            {t(m)}
+          </button>
+        ))}
+      </div>
+
+      {TOKEN_GROUPS.map(({ group, keys }) => (
+        <fieldset key={group} className="space-y-3">
+          <legend className="mb-1 font-mono text-[0.7rem] uppercase tracking-[0.18em] text-muted">
+            {t(`group.${group}`)}
+          </legend>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {keys.map((key) => (
+              <ColorField
+                key={key}
+                id={`tk-${mode}-${key}`}
+                label={t(`token.${key}`)}
+                helper={t(`tokenDesc.${key}`)}
+                value={tokens[key]}
+                onChange={(hex) => setToken(key, hex)}
+              />
+            ))}
+          </div>
+        </fieldset>
+      ))}
+    </div>
+  );
+}
+
+/* ===================== Hero & SEO ===================== */
+
+function CharCount({ value, max }: { value: string; max: number }) {
+  return (
+    <span className="font-mono text-[0.72rem] tabular-nums text-muted">
+      {value.length}/{max}
+    </span>
+  );
+}
+
+export function HeroSeoSection({ branding, patch }: BrandingSectionProps) {
+  const t = useTranslations("adminSettings.hero");
+  const metaTitle = branding.metaTitle ?? "";
+  const metaDesc = branding.metaDescription ?? "";
+
+  return (
+    <div className="space-y-6">
+      <fieldset className="space-y-4">
+        <legend className="mb-1 font-mono text-[0.7rem] uppercase tracking-[0.18em] text-muted">
+          {t("heroGroup")}
+        </legend>
+        <GlassField label={t("heroTitle")} htmlFor="h-title" helper={t("heroTitleHelper")}>
+          <GlassInput
+            id="h-title"
+            value={branding.heroTitle ?? ""}
+            onChange={(e) =>
+              patch({ heroTitle: e.target.value || null })
+            }
+          />
+        </GlassField>
+        <GlassField label={t("heroSubtitle")} htmlFor="h-sub">
+          <GlassTextarea
+            id="h-sub"
+            rows={2}
+            value={branding.heroSubtitle ?? ""}
+            onChange={(e) =>
+              patch({ heroSubtitle: e.target.value || null })
+            }
+          />
+        </GlassField>
+        <GlassField label={t("heroCta")} htmlFor="h-cta">
+          <GlassInput
+            id="h-cta"
+            value={branding.heroCta ?? ""}
+            onChange={(e) => patch({ heroCta: e.target.value || null })}
+          />
+        </GlassField>
+      </fieldset>
+
+      <fieldset className="space-y-4">
+        <legend className="mb-1 font-mono text-[0.7rem] uppercase tracking-[0.18em] text-muted">
+          {t("seoGroup")}
+        </legend>
+        <GlassField
+          label={
+            <span className="flex items-center justify-between">
+              {t("metaTitle")}
+              <CharCount value={metaTitle} max={60} />
+            </span>
+          }
+          htmlFor="m-title"
+          helper={t("metaTitleHelper")}
+        >
+          <GlassInput
+            id="m-title"
+            maxLength={70}
+            value={metaTitle}
+            onChange={(e) => patch({ metaTitle: e.target.value || null })}
+          />
+        </GlassField>
+        <GlassField
+          label={
+            <span className="flex items-center justify-between">
+              {t("metaDescription")}
+              <CharCount value={metaDesc} max={160} />
+            </span>
+          }
+          htmlFor="m-desc"
+          helper={t("metaDescriptionHelper")}
+        >
+          <GlassTextarea
+            id="m-desc"
+            rows={3}
+            maxLength={180}
+            value={metaDesc}
+            onChange={(e) =>
+              patch({ metaDescription: e.target.value || null })
+            }
+          />
+        </GlassField>
+        <GlassField label={t("favicon")} htmlFor="m-favicon" helper={t("faviconHelper")}>
+          <div className="flex items-center gap-3">
+            <span className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-[var(--r-sm)] border border-[color:var(--glass-border)] bg-[color:var(--glass-bg-strong)]">
+              {branding.favicon ? (
+                <img
+                  src={branding.favicon}
+                  alt=""
+                  className="h-7 w-7 object-contain"
+                />
+              ) : (
+                <ImageIcon size={18} />
+              )}
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col gap-2">
+              <GlassInput
+                id="m-favicon"
+                type="url"
+                inputMode="url"
+                placeholder="https://…/favicon.ico"
+                value={branding.favicon ?? ""}
+                onChange={(e) => patch({ favicon: e.target.value || null })}
+              />
+              <ImageUploader
+                label={t("faviconUpload")}
+                errorLabel={t("uploadError")}
+                onUploaded={(url) => patch({ favicon: url })}
+              />
+            </div>
+          </div>
+        </GlassField>
+      </fieldset>
+    </div>
+  );
+}
+
+/* ===================== Access ===================== */
+
+export function AccessSection({ settings, patch }: SettingsSectionProps) {
+  const t = useTranslations("adminSettings.access");
+  return (
+    <div className="space-y-5">
+      <GlassToggle
+        id="s-signup"
+        checked={settings.signupOpen}
+        onChange={(v) => patch({ signupOpen: v })}
+        label={t("signupOpen")}
+        description={t("signupOpenHelper")}
+        stateLabel={{ on: t("open"), off: t("closed") }}
+      />
+    </div>
+  );
+}
+
+/* ===================== Media ===================== */
+
+export function MediaSection({ settings, patch }: SettingsSectionProps) {
+  const t = useTranslations("adminSettings.media");
+  return (
+    <div className="grid gap-5 sm:grid-cols-2">
+      <GlassField
+        label={t("userQuota")}
+        htmlFor="s-user-quota"
+        helper={t("userQuotaHelper")}
+      >
+        <div className="relative">
+          <GlassInput
+            id="s-user-quota"
+            type="number"
+            min={1}
+            className="pr-12"
+            value={settings.mediaUserQuotaMb}
+            onChange={(e) =>
+              patch({ mediaUserQuotaMb: Number(e.target.value) })
+            }
+          />
+          <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[0.8rem] text-muted">
+            MB
+          </span>
+        </div>
+      </GlassField>
+      <GlassField
+        label={t("instanceQuota")}
+        htmlFor="s-instance-quota"
+        helper={t("instanceQuotaHelper")}
+      >
+        <div className="relative">
+          <GlassInput
+            id="s-instance-quota"
+            type="number"
+            min={1}
+            className="pr-12"
+            value={settings.mediaInstanceQuotaMb}
+            onChange={(e) =>
+              patch({ mediaInstanceQuotaMb: Number(e.target.value) })
+            }
+          />
+          <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[0.8rem] text-muted">
+            MB
+          </span>
+        </div>
+      </GlassField>
+    </div>
+  );
+}
+
+/* ===================== AI ===================== */
+
+export interface AiSectionProps extends SettingsSectionProps {
+  apiKey: string;
+  onApiKey: (v: string) => void;
+}
+
+export function AiSection({
+  settings,
+  patch,
+  apiKey,
+  onApiKey,
+}: AiSectionProps) {
+  const t = useTranslations("adminSettings.ai");
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-5 sm:grid-cols-2">
+        <GlassField label={t("apiUrl")} htmlFor="ai-url">
+          <GlassInput
+            id="ai-url"
+            type="url"
+            inputMode="url"
+            placeholder="https://api.openai.com/v1"
+            value={settings.aiApiUrl}
+            onChange={(e) => patch({ aiApiUrl: e.target.value })}
+          />
+        </GlassField>
+        <GlassField label={t("model")} htmlFor="ai-model">
+          <GlassInput
+            id="ai-model"
+            value={settings.aiModel}
+            onChange={(e) => patch({ aiModel: e.target.value })}
+          />
+        </GlassField>
+      </div>
+
+      <GlassField
+        label={
+          <span className="flex items-center gap-2">
+            {t("apiKey")}
+            {settings.aiApiKeySet ? (
+              <GlassChip size="sm" variant="success">
+                <KeyIcon size={11} />
+                {t("keyConfigured")}
+              </GlassChip>
+            ) : (
+              <GlassChip size="sm" variant="warning">
+                {t("keyMissing")}
+              </GlassChip>
+            )}
+          </span>
+        }
+        htmlFor="ai-key"
+        helper={t("apiKeyHelper")}
+      >
+        <GlassInput
+          id="ai-key"
+          type="password"
+          autoComplete="off"
+          placeholder={
+            settings.aiApiKeySet ? t("keyPlaceholderSet") : t("keyPlaceholder")
+          }
+          value={apiKey}
+          onChange={(e) => onApiKey(e.target.value)}
+        />
+      </GlassField>
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        <RangeField
+          id="ai-temp"
+          label={t("temperature")}
+          value={settings.aiTemperature}
+          min={0}
+          max={2}
+          step={0.1}
+          onChange={(v) => patch({ aiTemperature: v })}
+          format={(v) => v.toFixed(1)}
+          helper={t("temperatureHelper")}
+        />
+        <RangeField
+          id="ai-tokens"
+          label={t("maxTokens")}
+          value={settings.aiMaxTokens}
+          min={256}
+          max={32000}
+          step={256}
+          onChange={(v) => patch({ aiMaxTokens: v })}
+          format={(v) => v.toLocaleString()}
+          helper={t("maxTokensHelper")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/admin/settings/settings-workspace.tsx
+++ b/apps/frontend/components/admin/settings/settings-workspace.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+// Admin settings editor — section rail, dirty-tracking save bar, live branding preview.
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+
+import { updateBranding } from "@/app/actions/instance";
+import { updateSettings } from "@/app/actions/settings";
+import { GlassButton } from "@/components/ui/glass-button";
+import { GlassCard, GlassCardContent } from "@/components/ui/glass-card";
+import {
+  AlertCircleIcon,
+  CheckCircleIcon,
+  CodeIcon,
+  ImageIcon,
+  KeyIcon,
+  SparklesIcon,
+  StarIcon,
+  TypeIcon,
+} from "@/components/ui/icons";
+import { DEFAULT_INSTANCE, DEFAULT_THEME_TOKENS } from "@/lib/instance";
+import { cn } from "@/lib/utils";
+import type {
+  InstanceBranding,
+  InstanceSettings,
+  UpdateBrandingPayload,
+  UpdateSettingsPayload,
+} from "@/lib/types";
+
+import {
+  AccessSection,
+  AiSection,
+  HeroSeoSection,
+  IdentitySection,
+  MediaSection,
+  ThemeSection,
+} from "./settings-sections";
+
+// Default values used by the per-section reset (platform settings side).
+const DEFAULT_SETTINGS: Pick<
+  InstanceSettings,
+  | "signupOpen"
+  | "mediaUserQuotaMb"
+  | "mediaInstanceQuotaMb"
+  | "aiApiUrl"
+  | "aiModel"
+  | "aiMaxTokens"
+  | "aiTemperature"
+> = {
+  signupOpen: true,
+  mediaUserQuotaMb: 100,
+  mediaInstanceQuotaMb: 5000,
+  aiApiUrl: "",
+  aiModel: "",
+  aiMaxTokens: 4096,
+  aiTemperature: 0.7,
+};
+
+type SectionId =
+  | "identity"
+  | "theme"
+  | "hero"
+  | "access"
+  | "media"
+  | "ai";
+
+const SECTIONS: {
+  id: SectionId;
+  icon: React.ComponentType<{ size?: number }>;
+}[] = [
+  { id: "identity", icon: StarIcon },
+  { id: "theme", icon: SparklesIcon },
+  { id: "hero", icon: TypeIcon },
+  { id: "access", icon: KeyIcon },
+  { id: "media", icon: ImageIcon },
+  { id: "ai", icon: CodeIcon },
+];
+
+/* ---- diff helpers (only send changed fields) ---- */
+
+function brandingDiff(
+  a: InstanceBranding,
+  b: InstanceBranding
+): UpdateBrandingPayload {
+  const out: UpdateBrandingPayload = {};
+  if (a.name !== b.name) out.name = b.name;
+  if (a.tagline !== b.tagline) out.tagline = b.tagline;
+  if (a.logo.kind !== b.logo.kind || a.logo.value !== b.logo.value)
+    out.logo = b.logo;
+  if (a.accent !== b.accent) out.accent = b.accent;
+  if (a.heroTitle !== b.heroTitle) out.heroTitle = b.heroTitle;
+  if (a.heroSubtitle !== b.heroSubtitle) out.heroSubtitle = b.heroSubtitle;
+  if (a.heroCta !== b.heroCta) out.heroCta = b.heroCta;
+  if (a.locale !== b.locale) out.locale = b.locale;
+  if (a.favicon !== b.favicon) out.favicon = b.favicon;
+  if (a.metaTitle !== b.metaTitle) out.metaTitle = b.metaTitle;
+  if (a.metaDescription !== b.metaDescription)
+    out.metaDescription = b.metaDescription;
+  if (a.fontPreset !== b.fontPreset) out.fontPreset = b.fontPreset;
+  if (JSON.stringify(a.theme) !== JSON.stringify(b.theme)) out.theme = b.theme;
+  return out;
+}
+
+function settingsDiff(
+  a: InstanceSettings,
+  b: InstanceSettings
+): UpdateSettingsPayload {
+  const out: UpdateSettingsPayload = {};
+  if (a.signupOpen !== b.signupOpen) out.signupOpen = b.signupOpen;
+  if (a.mediaUserQuotaMb !== b.mediaUserQuotaMb)
+    out.mediaUserQuotaMb = b.mediaUserQuotaMb;
+  if (a.mediaInstanceQuotaMb !== b.mediaInstanceQuotaMb)
+    out.mediaInstanceQuotaMb = b.mediaInstanceQuotaMb;
+  if (a.aiApiUrl !== b.aiApiUrl) out.aiApiUrl = b.aiApiUrl;
+  if (a.aiModel !== b.aiModel) out.aiModel = b.aiModel;
+  if (a.aiMaxTokens !== b.aiMaxTokens) out.aiMaxTokens = b.aiMaxTokens;
+  if (a.aiTemperature !== b.aiTemperature) out.aiTemperature = b.aiTemperature;
+  return out;
+}
+
+function hasKeys(o: object): boolean {
+  return Object.keys(o).length > 0;
+}
+
+export function SettingsWorkspace({
+  initialBranding,
+  initialSettings,
+}: {
+  initialBranding: InstanceBranding;
+  initialSettings: InstanceSettings;
+}) {
+  const t = useTranslations("adminSettings");
+  const tErr = useTranslations("errors");
+  const router = useRouter();
+
+  const [savedBranding, setSavedBranding] = React.useState(initialBranding);
+  const [savedSettings, setSavedSettings] = React.useState(initialSettings);
+  const [branding, setBranding] = React.useState(initialBranding);
+  const [settings, setSettings] = React.useState(initialSettings);
+  const [apiKey, setApiKey] = React.useState("");
+
+  const [active, setActive] = React.useState<SectionId>("identity");
+  // Light/dark mode currently edited in the Theme section.
+  const [themeMode, setThemeMode] = React.useState<"light" | "dark">("light");
+  const [pending, start] = React.useTransition();
+  const [error, setError] = React.useState<string | null>(null);
+  const [saved, setSaved] = React.useState(false);
+
+  const bDiff = brandingDiff(savedBranding, branding);
+  const sDiff = settingsDiff(savedSettings, settings);
+  const apiKeyDirty = apiKey.trim().length > 0;
+  const dirty = hasKeys(bDiff) || hasKeys(sDiff) || apiKeyDirty;
+
+  const dirtySections = React.useMemo(() => {
+    const s = new Set<SectionId>();
+    if (
+      bDiff.name !== undefined ||
+      bDiff.tagline !== undefined ||
+      bDiff.logo !== undefined ||
+      bDiff.accent !== undefined ||
+      bDiff.locale !== undefined ||
+      bDiff.fontPreset !== undefined
+    )
+      s.add("identity");
+    if (bDiff.theme !== undefined) s.add("theme");
+    if (
+      bDiff.heroTitle !== undefined ||
+      bDiff.heroSubtitle !== undefined ||
+      bDiff.heroCta !== undefined ||
+      bDiff.metaTitle !== undefined ||
+      bDiff.metaDescription !== undefined ||
+      bDiff.favicon !== undefined
+    )
+      s.add("hero");
+    if (sDiff.signupOpen !== undefined) s.add("access");
+    if (
+      sDiff.mediaUserQuotaMb !== undefined ||
+      sDiff.mediaInstanceQuotaMb !== undefined
+    )
+      s.add("media");
+    if (
+      sDiff.aiApiUrl !== undefined ||
+      sDiff.aiModel !== undefined ||
+      sDiff.aiMaxTokens !== undefined ||
+      sDiff.aiTemperature !== undefined ||
+      apiKeyDirty
+    )
+      s.add("ai");
+    return s;
+  }, [bDiff, sDiff, apiKeyDirty]);
+
+  const patchBranding = React.useCallback(
+    (partial: Partial<InstanceBranding>) => {
+      setSaved(false);
+      setBranding((prev) => ({ ...prev, ...partial }));
+    },
+    []
+  );
+  const patchSettings = React.useCallback(
+    (partial: Partial<InstanceSettings>) => {
+      setSaved(false);
+      setSettings((prev) => ({ ...prev, ...partial }));
+    },
+    []
+  );
+
+  function discard() {
+    setBranding(savedBranding);
+    setSettings(savedSettings);
+    setApiKey("");
+    setError(null);
+    setSaved(false);
+  }
+
+  // Reset the active section's fields back to their default values.
+  function resetSection(id: SectionId) {
+    switch (id) {
+      case "identity":
+        patchBranding({
+          name: DEFAULT_INSTANCE.name,
+          tagline: DEFAULT_INSTANCE.tagline,
+          logo: DEFAULT_INSTANCE.logo,
+          accent: DEFAULT_INSTANCE.accent,
+          locale: DEFAULT_INSTANCE.locale,
+          fontPreset: DEFAULT_INSTANCE.fontPreset,
+        });
+        break;
+      case "theme":
+        patchBranding({
+          theme: {
+            light: { ...DEFAULT_THEME_TOKENS.light },
+            dark: { ...DEFAULT_THEME_TOKENS.dark },
+          },
+        });
+        break;
+      case "hero":
+        patchBranding({
+          heroTitle: null,
+          heroSubtitle: null,
+          heroCta: null,
+          metaTitle: null,
+          metaDescription: null,
+          favicon: null,
+        });
+        break;
+      case "access":
+        patchSettings({ signupOpen: DEFAULT_SETTINGS.signupOpen });
+        break;
+      case "media":
+        patchSettings({
+          mediaUserQuotaMb: DEFAULT_SETTINGS.mediaUserQuotaMb,
+          mediaInstanceQuotaMb: DEFAULT_SETTINGS.mediaInstanceQuotaMb,
+        });
+        break;
+      case "ai":
+        patchSettings({
+          aiApiUrl: DEFAULT_SETTINGS.aiApiUrl,
+          aiModel: DEFAULT_SETTINGS.aiModel,
+          aiMaxTokens: DEFAULT_SETTINGS.aiMaxTokens,
+          aiTemperature: DEFAULT_SETTINGS.aiTemperature,
+        });
+        setApiKey("");
+        break;
+    }
+  }
+
+  function save() {
+    setError(null);
+    setSaved(false);
+    start(async () => {
+      // Branding
+      if (hasKeys(bDiff)) {
+        const r = await updateBranding(bDiff);
+        if (!r.ok) {
+          setError(r.error ?? tErr("unknown"));
+          return;
+        }
+        if (r.data) {
+          setSavedBranding(r.data);
+          setBranding(r.data);
+        } else {
+          setSavedBranding(branding);
+        }
+      }
+      // Platform settings (+ optional write-only key)
+      const settingsPayload: UpdateSettingsPayload = { ...sDiff };
+      if (apiKeyDirty) settingsPayload.aiApiKey = apiKey.trim();
+      if (hasKeys(settingsPayload)) {
+        const r = await updateSettings(settingsPayload);
+        if (!r.ok) {
+          setError(r.error ?? tErr("unknown"));
+          return;
+        }
+        if (r.data) {
+          setSavedSettings(r.data);
+          setSettings(r.data);
+        } else {
+          setSavedSettings(settings);
+        }
+      }
+      setApiKey("");
+      setSaved(true);
+      // Propagate branding (accent/theme/fonts/favicon) to the root layout.
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="lg:grid lg:grid-cols-[180px_minmax(0,1fr)] lg:gap-6">
+      {/* ── Rail nav ── */}
+      <nav
+        aria-label={t("title")}
+        className="mb-4 lg:mb-0"
+      >
+        <ul className="flex gap-1 overflow-x-auto pb-1 lg:sticky lg:top-24 lg:flex-col lg:overflow-visible lg:pb-0">
+          {SECTIONS.map(({ id, icon: Icon }) => {
+            const isActive = active === id;
+            const sectionDirty = dirtySections.has(id);
+            return (
+              <li key={id} className="shrink-0">
+                <button
+                  type="button"
+                  aria-current={isActive ? "page" : undefined}
+                  onClick={() => setActive(id)}
+                  className={cn(
+                    "flex w-full items-center gap-2.5 rounded-[var(--r)] px-3 py-2.5 text-left",
+                    "text-[0.9rem] font-medium transition-colors duration-150 cursor-pointer",
+                    isActive
+                      ? "bg-[color:var(--color-accent-soft)] text-[color:var(--color-accent)]"
+                      : "text-text-soft hover:bg-[color:var(--glass-bg)] hover:text-text"
+                  )}
+                >
+                  <Icon size={17} />
+                  <span className="whitespace-nowrap">{t(`nav.${id}`)}</span>
+                  {sectionDirty && (
+                    <span
+                      aria-hidden
+                      className="ml-auto h-1.5 w-1.5 rounded-full bg-[color:var(--color-accent)]"
+                    />
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      {/* ── Content ── */}
+      <div className="min-w-0">
+        {/* Save bar */}
+        <div
+          className={cn(
+            "sticky top-20 z-20 mb-5 transition-all duration-200",
+            dirty || saved || error
+              ? "opacity-100"
+              : "pointer-events-none h-0 overflow-hidden opacity-0"
+          )}
+        >
+          <GlassCard variant="tinted">
+            <GlassCardContent className="flex flex-wrap items-center justify-between gap-3 p-3 pl-4">
+              <span className="flex items-center gap-2 text-[0.85rem]">
+                {error ? (
+                  <>
+                    <span className="text-[color:var(--color-danger)]">
+                      <AlertCircleIcon size={16} />
+                    </span>
+                    <span className="text-[color:var(--color-danger)]">
+                      {error}
+                    </span>
+                  </>
+                ) : saved && !dirty ? (
+                  <>
+                    <span className="text-[color:var(--color-success)]">
+                      <CheckCircleIcon size={16} />
+                    </span>
+                    <span className="text-text-soft">{t("saved")}</span>
+                  </>
+                ) : (
+                  <span className="text-text-soft">{t("unsaved")}</span>
+                )}
+              </span>
+              <div className="flex items-center gap-2">
+                <GlassButton
+                  variant="ghost"
+                  size="sm"
+                  onClick={discard}
+                  disabled={!dirty || pending}
+                >
+                  {t("discard")}
+                </GlassButton>
+                <GlassButton
+                  variant="primary"
+                  size="sm"
+                  onClick={save}
+                  disabled={!dirty || pending}
+                >
+                  {pending ? t("saving") : t("save")}
+                </GlassButton>
+              </div>
+            </GlassCardContent>
+          </GlassCard>
+        </div>
+
+        <GlassCard variant="default">
+          <GlassCardContent className="p-6">
+            <header className="mb-5 flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h2 className="font-display text-xl text-text">
+                  {t(`nav.${active}`)}
+                </h2>
+                <p className="mt-1 text-[0.85rem] text-text-soft">
+                  {t(`sectionDescription.${active}`)}
+                </p>
+              </div>
+              <GlassButton
+                variant="ghost"
+                size="sm"
+                onClick={() => resetSection(active)}
+                className="shrink-0"
+              >
+                {t("resetSection")}
+              </GlassButton>
+            </header>
+
+            {active === "identity" && (
+              <IdentitySection branding={branding} patch={patchBranding} />
+            )}
+            {active === "theme" && (
+              <ThemeSection
+                branding={branding}
+                patch={patchBranding}
+                mode={themeMode}
+                onMode={setThemeMode}
+              />
+            )}
+            {active === "hero" && (
+              <HeroSeoSection branding={branding} patch={patchBranding} />
+            )}
+            {active === "access" && (
+              <AccessSection settings={settings} patch={patchSettings} />
+            )}
+            {active === "media" && (
+              <MediaSection settings={settings} patch={patchSettings} />
+            )}
+            {active === "ai" && (
+              <AiSection
+                settings={settings}
+                patch={patchSettings}
+                apiKey={apiKey}
+                onApiKey={(v) => {
+                  setSaved(false);
+                  setApiKey(v);
+                }}
+              />
+            )}
+          </GlassCardContent>
+        </GlassCard>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/admin/settings/settings-workspace.tsx
+++ b/apps/frontend/components/admin/settings/settings-workspace.tsx
@@ -349,10 +349,10 @@ export function SettingsWorkspace({
 
       {/* ── Content ── */}
       <div className="min-w-0">
-        {/* Save bar */}
+        {/* Save bar — opaque backing so scrolled content never shows through. */}
         <div
           className={cn(
-            "sticky top-20 z-20 mb-5 transition-all duration-200",
+            "sticky top-20 z-30 mb-5 rounded-[var(--r-lg)] bg-bg-base shadow-xl transition-all duration-200",
             dirty || saved || error
               ? "opacity-100"
               : "pointer-events-none h-0 overflow-hidden opacity-0"

--- a/apps/frontend/components/brand-mark.tsx
+++ b/apps/frontend/components/brand-mark.tsx
@@ -1,6 +1,6 @@
 /**
  * Logo / mark de l'instance — étoile par défaut.
- * Le preset et l'accent peuvent être surchargés via `instance.json`.
+ * Le logo (preset ou image téléversée) et l'accent proviennent du branding (Settings).
  */
 
 import * as React from "react";
@@ -12,6 +12,9 @@ export type LogoPreset = "star" | "alpha" | "flame" | "hash";
 interface BrandMarkProps {
   size?: number;
   accent?: string;
+  /** Full logo descriptor; when kind !== "preset", `value` is an image URL. */
+  logo?: { kind: string; value: string };
+  /** Legacy: preset name when no `logo` object is provided. */
   preset?: LogoPreset;
   className?: string;
 }
@@ -26,11 +29,39 @@ const PRESET_GLYPH: Record<LogoPreset, string | null> = {
 export function BrandMark({
   size = 28,
   accent = DEFAULT_INSTANCE.accent,
-  preset = DEFAULT_INSTANCE.logo.value as LogoPreset,
+  logo,
+  preset,
   className,
 }: BrandMarkProps) {
-  const glyph = PRESET_GLYPH[preset];
-  const gradientID = "mark-" + String(accent).replace(/[^a-zA-Z0-9_-]/g, "")
+  // Uploaded / URL logo wins over presets.
+  const imageSrc =
+    logo && logo.kind !== "preset" && logo.value ? logo.value : null;
+
+  if (imageSrc) {
+    return (
+      <img
+        src={imageSrc}
+        alt=""
+        width={size}
+        height={size}
+        className={className}
+        style={{
+          width: size,
+          height: size,
+          borderRadius: size * 0.3,
+          objectFit: "contain",
+        }}
+      />
+    );
+  }
+
+  const presetName: LogoPreset =
+    (logo?.kind === "preset" ? (logo.value as LogoPreset) : undefined) ??
+    preset ??
+    (DEFAULT_INSTANCE.logo.value as LogoPreset);
+
+  const glyph = PRESET_GLYPH[presetName];
+  const gradientID = "mark-" + String(accent).replace(/[^a-zA-Z0-9_-]/g, "");
 
   if (glyph) {
     return (

--- a/apps/frontend/components/site-footer.tsx
+++ b/apps/frontend/components/site-footer.tsx
@@ -22,7 +22,7 @@ export async function SiteFooter() {
     <footer className="relative mt-32 border-t border-[color:var(--glass-border)]">
       <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-10 md:flex-row md:items-center md:justify-between md:px-8">
         <div className="flex items-center gap-3">
-          <BrandMark size={26} preset={branding.logo.value as "star" | "alpha" | "flame" | "hash"} accent={branding.accent} />
+          <BrandMark size={26} logo={branding.logo} accent={branding.accent} />
           <div className="flex flex-col">
             <span className="font-semibold text-text">{branding.name}</span>
             <span className="text-[0.78rem] text-muted">

--- a/apps/frontend/components/top-nav.tsx
+++ b/apps/frontend/components/top-nav.tsx
@@ -11,7 +11,7 @@ import { getTranslations } from "next-intl/server";
 
 import { getMe } from "@/app/actions/auth";
 import { getInstanceBranding } from "@/app/actions/instance";
-import { BrandMark, type LogoPreset } from "@/components/brand-mark";
+import { BrandMark } from "@/components/brand-mark";
 import { UserMenu } from "@/components/user-menu";
 import { GlassButton } from "@/components/ui/glass-button";
 import { GlassNav, GlassNavInner } from "@/components/ui/glass-nav";
@@ -25,8 +25,6 @@ export async function TopNav() {
     getMe(),
   ]);
 
-  const preset = branding.logo.value as LogoPreset;
-
   return (
     <GlassNav>
       <GlassNavInner>
@@ -35,7 +33,7 @@ export async function TopNav() {
           className="inline-flex items-center gap-2.5 rounded-full"
           aria-label={t("homeAria", { name: branding.name })}
         >
-          <BrandMark size={28} preset={preset} accent={branding.accent} />
+          <BrandMark size={28} logo={branding.logo} accent={branding.accent} />
           <span className="font-semibold text-text">{branding.name}</span>
         </Link>
 

--- a/apps/frontend/components/top-nav.tsx
+++ b/apps/frontend/components/top-nav.tsx
@@ -70,6 +70,14 @@ export async function TopNav() {
                 {isAdmin(me.role) ? t("admin") : t("teach")}
               </Link>
             )}
+            {isStaff(me.role) && (
+              <Link
+                href="/admin/groups"
+                className="rounded-full px-3 py-1.5 text-[0.88rem] text-text-soft hover:bg-[color:var(--glass-bg)] hover:text-text"
+              >
+                {t("groups")}
+              </Link>
+            )}
           </nav>
         )}
 

--- a/apps/frontend/components/ui/glass-controls.tsx
+++ b/apps/frontend/components/ui/glass-controls.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+import { GlassFieldHelper, GlassLabel } from "./glass-input";
+
+/* ============================================================
+   Glass form controls: toggle switch, color field, range slider.
+   Built on the same glass tokens as GlassInput.
+   ============================================================ */
+
+/* ---- Toggle (switch) ---- */
+
+interface GlassToggleProps {
+  id?: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  /** Short text shown next to the switch reflecting the current state. */
+  stateLabel?: { on: string; off: string };
+  disabled?: boolean;
+}
+
+export function GlassToggle({
+  id,
+  checked,
+  onChange,
+  label,
+  description,
+  stateLabel,
+  disabled,
+}: GlassToggleProps) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="min-w-0">
+        <GlassLabel htmlFor={id} className="mb-0.5">
+          {label}
+        </GlassLabel>
+        {description && <GlassFieldHelper>{description}</GlassFieldHelper>}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {stateLabel && (
+          <span
+            className={cn(
+              "text-[0.78rem] font-medium tabular-nums",
+              checked
+                ? "text-[color:var(--color-success)]"
+                : "text-muted"
+            )}
+          >
+            {checked ? stateLabel.on : stateLabel.off}
+          </span>
+        )}
+        <button
+          id={id}
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          disabled={disabled}
+          onClick={() => onChange(!checked)}
+          className={cn(
+            "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full",
+            "border border-[color:var(--glass-border)] transition-colors duration-200",
+            "focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_var(--color-accent-soft)]",
+            "disabled:cursor-not-allowed disabled:opacity-60",
+            checked
+              ? "bg-[color:var(--color-accent)]"
+              : "bg-[color:var(--glass-bg-strong)]"
+          )}
+        >
+          <span
+            className={cn(
+              "inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform duration-200",
+              checked ? "translate-x-6" : "translate-x-1"
+            )}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ---- Color field (swatch + hex) ---- */
+
+const HEX_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+export function isHexColor(v: string): boolean {
+  return HEX_RE.test(v.trim());
+}
+
+interface ColorFieldProps {
+  id?: string;
+  label: React.ReactNode;
+  value: string;
+  onChange: (hex: string) => void;
+  helper?: React.ReactNode;
+}
+
+export function ColorField({
+  id,
+  label,
+  value,
+  onChange,
+  helper,
+}: ColorFieldProps) {
+  const valid = isHexColor(value);
+  // Native <input type=color> only accepts 6-digit hex.
+  const swatchValue = valid && value.length === 7 ? value : "#000000";
+
+  return (
+    <div className="group w-full">
+      <GlassLabel htmlFor={id}>
+        <span className="transition-colors group-focus-within:text-[color:var(--color-accent)]">
+          {label}
+        </span>
+      </GlassLabel>
+      <div className="flex items-center gap-2">
+        <span className="relative inline-flex h-10 w-10 shrink-0 overflow-hidden rounded-[var(--r-sm)] border border-[color:var(--glass-border)]">
+          <input
+            id={id}
+            type="color"
+            aria-label={typeof label === "string" ? label : undefined}
+            value={swatchValue}
+            onChange={(e) => onChange(e.target.value)}
+            className="absolute inset-[-25%] h-[150%] w-[150%] cursor-pointer border-0 bg-transparent p-0"
+          />
+        </span>
+        <input
+          type="text"
+          inputMode="text"
+          spellCheck={false}
+          aria-label={
+            typeof label === "string" ? `${label} (hex)` : undefined
+          }
+          aria-invalid={!valid || undefined}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className={cn(
+            "h-10 w-32 rounded-[var(--r-sm)] px-3 font-mono text-[0.85rem] text-text",
+            "border border-[color:var(--glass-border)] bg-[color:var(--glass-bg-strong)]",
+            "transition-[box-shadow,border-color] duration-150",
+            "focus:border-[color:var(--color-accent)] focus:outline-none",
+            "focus:shadow-[0_0_0_3px_var(--color-accent-soft)]",
+            !valid &&
+              "border-[color:var(--color-danger)] focus:shadow-[0_0_0_3px_color-mix(in_oklab,var(--color-danger)_30%,transparent)]"
+          )}
+        />
+      </div>
+      {helper && <GlassFieldHelper>{helper}</GlassFieldHelper>}
+    </div>
+  );
+}
+
+/* ---- Range slider ---- */
+
+interface RangeFieldProps {
+  id?: string;
+  label: React.ReactNode;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (next: number) => void;
+  /** Render the value (e.g. add a unit). Defaults to the raw number. */
+  format?: (v: number) => string;
+  helper?: React.ReactNode;
+}
+
+export function RangeField({
+  id,
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+  format,
+  helper,
+}: RangeFieldProps) {
+  return (
+    <div className="w-full">
+      <div className="mb-1.5 flex items-baseline justify-between gap-3">
+        <GlassLabel htmlFor={id} className="mb-0">
+          {label}
+        </GlassLabel>
+        <span className="font-mono text-[0.85rem] tabular-nums text-text">
+          {format ? format(value) : value}
+        </span>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="h-2 w-full cursor-pointer appearance-none rounded-full bg-[color:var(--color-accent-soft)] accent-[color:var(--color-accent)]"
+      />
+      {helper && <GlassFieldHelper>{helper}</GlassFieldHelper>}
+    </div>
+  );
+}

--- a/apps/frontend/lib/branding-css.ts
+++ b/apps/frontend/lib/branding-css.ts
@@ -1,0 +1,83 @@
+/**
+ * Maps branding (accent + theme tokens + font preset) onto the CSS custom
+ * properties consumed by globals.css. Shared between the server RootLayout and
+ * the client-side live preview so both stay in sync.
+ */
+
+import { resolveFontPreset } from "./fonts";
+import type { InstanceBranding, ThemeTokens } from "./types";
+
+export type ResolvedTheme = "light" | "dark";
+
+/** The `--color-*-raw` variables for one light/dark token set. */
+export function themeTokensToVars(t: ThemeTokens): Record<string, string> {
+  return {
+    "--color-bg-base-raw": t.bgBase,
+    "--color-bg-mesh-1-raw": t.bgMesh1,
+    "--color-bg-mesh-2-raw": t.bgMesh2,
+    "--color-bg-mesh-3-raw": t.bgMesh3,
+    "--color-text-raw": t.text,
+    "--color-text-soft-raw": t.textSoft,
+    "--color-muted-raw": t.muted,
+    "--color-success-raw": t.success,
+    "--color-warning-raw": t.warning,
+    "--color-danger-raw": t.danger,
+    "--color-green-raw": t.green,
+    "--color-tip-raw": t.tip,
+  };
+}
+
+/**
+ * Full set of CSS variables for a branding at a given resolved theme.
+ * `--color-accent-soft-raw` is derived from the accent so custom accents keep
+ * a matching soft tint.
+ */
+export function brandingToCssVars(
+  branding: InstanceBranding,
+  resolved: ResolvedTheme
+): Record<string, string> {
+  const tokens = branding.theme[resolved];
+  const preset = resolveFontPreset(branding.fontPreset);
+  const softPct = resolved === "dark" ? "24%" : "16%";
+  return {
+    ...themeTokensToVars(tokens),
+    "--color-accent-raw": branding.accent,
+    "--color-accent-soft-raw": `color-mix(in srgb, ${branding.accent} ${softPct}, transparent)`,
+    "--font-sans": preset.sans,
+    "--font-display": preset.display,
+  };
+}
+
+function varsToBlock(vars: Record<string, string>): string {
+  return Object.entries(vars)
+    .map(([k, v]) => `${k}:${v};`)
+    .join("");
+}
+
+/**
+ * CSS injected once in the document head so branding overrides globals.css for
+ * BOTH themes. Using `[data-theme]` selectors (not inline styles) keeps the
+ * client-side light/dark toggle working. `html`-prefixed selectors raise
+ * specificity so this always wins over the stylesheet defaults.
+ */
+export function brandingThemeCss(branding: InstanceBranding): string {
+  const preset = resolveFontPreset(branding.fontPreset);
+  const root = varsToBlock({
+    "--color-accent-raw": branding.accent,
+    "--font-sans": preset.sans,
+    "--font-display": preset.display,
+  });
+  const light = varsToBlock({
+    ...themeTokensToVars(branding.theme.light),
+    "--color-accent-soft-raw": `color-mix(in srgb, ${branding.accent} 16%, transparent)`,
+  });
+  const dark = varsToBlock({
+    ...themeTokensToVars(branding.theme.dark),
+    "--color-accent-soft-raw": `color-mix(in srgb, ${branding.accent} 24%, transparent)`,
+  });
+  return [
+    `html{${root}}`,
+    `html,html[data-theme="light"]{${light}}`,
+    `html[data-theme="dark"]{${dark}}`,
+  ].join("");
+}

--- a/apps/frontend/lib/fonts.ts
+++ b/apps/frontend/lib/fonts.ts
@@ -1,0 +1,53 @@
+/**
+ * Font preset registry.
+ *
+ * Each preset maps to a {sans, display} pair of CSS variables that are loaded
+ * by the RootLayout via next/font. Applying a preset overrides the global
+ * `--font-sans` / `--font-display` tokens consumed across the app.
+ */
+
+export interface FontPreset {
+  id: string;
+  label: string;
+  /** CSS value for --font-sans (body). */
+  sans: string;
+  /** CSS value for --font-display (headings). */
+  display: string;
+}
+
+const SANS_FALLBACK =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+const SERIF_FALLBACK = "Georgia, serif";
+
+export const FONT_PRESETS: FontPreset[] = [
+  {
+    id: "outfit-instrument",
+    label: "Outfit · Instrument Serif",
+    sans: `var(--font-outfit), ${SANS_FALLBACK}`,
+    display: `var(--font-instrument), ${SERIF_FALLBACK}`,
+  },
+  {
+    id: "inter-fraunces",
+    label: "Inter · Fraunces",
+    sans: `var(--font-inter), ${SANS_FALLBACK}`,
+    display: `var(--font-fraunces), ${SERIF_FALLBACK}`,
+  },
+  {
+    id: "inter-instrument",
+    label: "Inter · Instrument Serif",
+    sans: `var(--font-inter), ${SANS_FALLBACK}`,
+    display: `var(--font-instrument), ${SERIF_FALLBACK}`,
+  },
+  {
+    id: "outfit-fraunces",
+    label: "Outfit · Fraunces",
+    sans: `var(--font-outfit), ${SANS_FALLBACK}`,
+    display: `var(--font-fraunces), ${SERIF_FALLBACK}`,
+  },
+];
+
+export const DEFAULT_FONT_PRESET = FONT_PRESETS[1]; // inter-fraunces (current look)
+
+export function resolveFontPreset(id: string | null | undefined): FontPreset {
+  return FONT_PRESETS.find((p) => p.id === id) ?? DEFAULT_FONT_PRESET;
+}

--- a/apps/frontend/lib/instance.ts
+++ b/apps/frontend/lib/instance.ts
@@ -1,16 +1,54 @@
 /**
  * Static fallback for the instance branding.
-*/
+ * Used when the backend is unreachable; mirrors the "Liquid Glass · Citron"
+ * tokens defined in app/globals.css so the fallback matches the real look.
+ */
 
-import type { InstanceBranding } from "./types";
+import type { BrandingTheme, InstanceBranding } from "./types";
+
+export const DEFAULT_THEME_TOKENS: BrandingTheme = {
+  light: {
+    bgBase: "#fbf9ee",
+    bgMesh1: "#fff1bf",
+    bgMesh2: "#ffe2be",
+    bgMesh3: "#ebf6c8",
+    text: "#1a1f2e",
+    textSoft: "#4a5366",
+    muted: "#8892a6",
+    success: "#2faa7e",
+    warning: "#e08a2b",
+    danger: "#e0556a",
+    green: "#5aa84a",
+    tip: "#d6a01f",
+  },
+  dark: {
+    bgBase: "#0e1422",
+    bgMesh1: "#38352a",
+    bgMesh2: "#332d26",
+    bgMesh3: "#2f3128",
+    text: "#edf1f9",
+    textSoft: "#b6c0d6",
+    muted: "#7c8ba8",
+    success: "#5dc9a8",
+    warning: "#ffb672",
+    danger: "#ff8a95",
+    green: "#7bc86c",
+    tip: "#ffd66b",
+  },
+};
 
 export const DEFAULT_INSTANCE: InstanceBranding = {
   name: "Codestar",
   tagline: "Open-source e-learning platform",
   logo: { kind: "preset", value: "star" },
-  accent: "#7AA9FF",
+  accent: "#EAB12E",
   heroTitle: null,
   heroSubtitle: null,
   heroCta: null,
   locale: "en",
+  favicon: null,
+  metaTitle: null,
+  metaDescription: null,
+  fontPreset: "inter-fraunces",
+  theme: DEFAULT_THEME_TOKENS,
 };

--- a/apps/frontend/lib/types.ts
+++ b/apps/frontend/lib/types.ts
@@ -162,8 +162,35 @@ export interface AiCourseDraft {
   pages: PageInput[];
 }
 
+/**
+ * Platform settings — mirrors backend SettingsDto (GET /api/v1/settings).
+ * The AI API key is never returned; `aiApiKeySet` only tells whether one is configured.
+ */
 export interface InstanceSettings {
-  maxBlocksPerPage: number;
+  signupOpen: boolean;
+  mediaUserQuotaMb: number;
+  mediaInstanceQuotaMb: number;
+  aiApiUrl: string;
+  aiModel: string;
+  aiMaxTokens: number;
+  aiTemperature: number;
+  aiApiKeySet: boolean;
+  /** Course builder: max blocks per page. */
+  maxBlocksPerPage?: number;
+}
+
+/** Partial patch payload for PATCH /api/v1/settings (only changed fields). */
+export interface UpdateSettingsPayload {
+  maxBlocksPerPage?: number;
+  signupOpen?: boolean;
+  mediaUserQuotaMb?: number;
+  mediaInstanceQuotaMb?: number;
+  aiApiUrl?: string;
+  /** Write-only: send to replace the stored key; never read back. */
+  aiApiKey?: string;
+  aiModel?: string;
+  aiMaxTokens?: number;
+  aiTemperature?: number;
 }
 
 export interface CourseMutationResult {
@@ -199,6 +226,31 @@ export interface BookmarkEnriched {
   createdAt: string;
 }
 
+/** One light/dark set of theme color tokens — mirrors backend ThemeTokens. */
+export interface ThemeTokens {
+  bgBase: string;
+  bgMesh1: string;
+  bgMesh2: string;
+  bgMesh3: string;
+  text: string;
+  textSoft: string;
+  muted: string;
+  success: string;
+  warning: string;
+  danger: string;
+  green: string;
+  tip: string;
+}
+
+export interface BrandingTheme {
+  light: ThemeTokens;
+  dark: ThemeTokens;
+}
+
+/**
+ * Instance branding — mirrors backend BrandingDto (GET /api/v1/settings/branding).
+ * Public read (landing before login); writes are Admin+.
+ */
 export interface InstanceBranding {
   name: string;
   tagline: string;
@@ -207,5 +259,27 @@ export interface InstanceBranding {
   heroTitle: string | null;
   heroSubtitle: string | null;
   heroCta: string | null;
-  locale: "en" | "fr";
+  locale: string;
+  favicon: string | null;
+  metaTitle: string | null;
+  metaDescription: string | null;
+  fontPreset: string;
+  theme: BrandingTheme;
+}
+
+/** Partial patch payload for PATCH /api/v1/settings/branding (only changed fields). */
+export interface UpdateBrandingPayload {
+  name?: string;
+  tagline?: string;
+  logo?: { kind: string; value: string };
+  accent?: string;
+  heroTitle?: string | null;
+  heroSubtitle?: string | null;
+  heroCta?: string | null;
+  locale?: string;
+  favicon?: string | null;
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+  fontPreset?: string;
+  theme?: BrandingTheme;
 }

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -8,7 +8,8 @@
     "catalog": "Catalog",
     "myCourses": "My courses",
     "teach": "Teach",
-    "admin": "Admin"
+    "admin": "Admin",
+    "groups": "Groups"
   },
   "footer": {
     "rights": "© {year} · All rights reserved",
@@ -294,13 +295,150 @@
   "adminSettings": {
     "kicker": "ADMIN · SETTINGS",
     "title": "Settings",
-    "description": "Instance settings, editable by administrators.",
+    "description": "Branding, theme and instance settings, editable by administrators.",
     "courseBuilderSection": "Course Builder",
     "maxBlocksLabel": "Max blocks per page",
     "maxBlocksHelper": "Between {min} and {max}. Caps how many blocks a course page may hold.",
     "maxBlocksRange": "Value must be an integer between {min} and {max}.",
     "save": "Save",
-    "saved": "✓ Saved"
+    "saved": "Changes saved",
+    "saving": "Saving…",
+    "discard": "Discard",
+    "unsaved": "Unsaved changes",
+    "resetSection": "Reset section",
+    "nav": {
+      "identity": "Identity",
+      "theme": "Theme",
+      "hero": "Home & SEO",
+      "access": "Access",
+      "media": "Media",
+      "ai": "AI"
+    },
+    "sectionDescription": {
+      "identity": "Instance name, logo, accent color and font.",
+      "theme": "Color palette for light and dark modes.",
+      "hero": "Landing page copy and SEO metadata.",
+      "access": "Platform access and signup rules.",
+      "media": "Storage quotas for uploaded files.",
+      "ai": "AI provider connection for course generation."
+    },
+    "preview": {
+      "title": "Live preview",
+      "themeSwitch": "Preview mode",
+      "light": "Light",
+      "dark": "Dark",
+      "heroFallback": "Learn, build, share.",
+      "ctaFallback": "Get started"
+    },
+    "identity": {
+      "name": "Instance name",
+      "tagline": "Tagline",
+      "logo": "Logo",
+      "logoHelper": "Mark shown next to the name.",
+      "logoPreset": {
+        "star": "Star",
+        "alpha": "Alpha",
+        "flame": "Flame",
+        "hash": "Hash"
+      },
+      "locale": "Default language",
+      "localeOption": {
+        "en": "English",
+        "fr": "French"
+      },
+      "accent": "Accent color",
+      "accentHelper": "Primary color for buttons and links.",
+      "font": "Font",
+      "fontHelper": "Font pairing (headings · body).",
+      "logoMode": {
+        "preset": "Preset",
+        "image": "Image"
+      },
+      "logoUpload": "Upload an image",
+      "logoReplace": "Replace image",
+      "uploadError": "Upload failed"
+    },
+    "theme": {
+      "modeSwitch": "Edited mode",
+      "light": "Light",
+      "dark": "Dark",
+      "reset": "Reset",
+      "group": {
+        "backgrounds": "Backgrounds",
+        "text": "Text",
+        "status": "Status"
+      },
+      "token": {
+        "bgBase": "Base background",
+        "bgMesh1": "Glow 1",
+        "bgMesh2": "Glow 2",
+        "bgMesh3": "Glow 3",
+        "text": "Text",
+        "textSoft": "Soft text",
+        "muted": "Muted text",
+        "success": "Success",
+        "warning": "Warning",
+        "danger": "Danger",
+        "green": "Green",
+        "tip": "Tip"
+      },
+      "tokenDesc": {
+        "bgBase": "Main page background color.",
+        "bgMesh1": "Background gradient glow.",
+        "bgMesh2": "Second gradient glow.",
+        "bgMesh3": "Third gradient glow.",
+        "text": "Primary text color.",
+        "textSoft": "Secondary, lower-contrast text.",
+        "muted": "Subtle text (captions, hints).",
+        "success": "Success messages and confirmations.",
+        "warning": "Warnings and light alerts.",
+        "danger": "Errors and destructive actions.",
+        "green": "Green accent (progress, achievements).",
+        "tip": "Tips and info callouts."
+      }
+    },
+    "hero": {
+      "heroGroup": "Landing page",
+      "heroTitle": "Hero title",
+      "heroTitleHelper": "Leave empty to use the default text.",
+      "heroSubtitle": "Subtitle",
+      "heroCta": "Call to action",
+      "seoGroup": "Search (SEO)",
+      "metaTitle": "Page title",
+      "metaTitleHelper": "Ideally under 60 characters.",
+      "metaDescription": "Meta description",
+      "metaDescriptionHelper": "Ideally under 160 characters.",
+      "favicon": "Favicon",
+      "faviconHelper": "URL of the icon shown in the browser tab.",
+      "faviconUpload": "Upload an image",
+      "uploadError": "Upload failed"
+    },
+    "access": {
+      "signupOpen": "Open signups",
+      "signupOpenHelper": "Allow new users to create an account.",
+      "open": "Open",
+      "closed": "Closed"
+    },
+    "media": {
+      "userQuota": "Per-user quota",
+      "userQuotaHelper": "Maximum storage per user.",
+      "instanceQuota": "Instance quota",
+      "instanceQuotaHelper": "Maximum total storage for the instance."
+    },
+    "ai": {
+      "apiUrl": "API URL",
+      "model": "Model",
+      "apiKey": "API key",
+      "apiKeyHelper": "Leave empty to keep the existing key.",
+      "keyConfigured": "Configured",
+      "keyMissing": "No key",
+      "keyPlaceholder": "Paste your API key",
+      "keyPlaceholderSet": "•••••••••• (replace)",
+      "temperature": "Temperature",
+      "temperatureHelper": "Response creativity (0 = strict, 2 = creative).",
+      "maxTokens": "Max tokens",
+      "maxTokensHelper": "Maximum length of generated responses."
+    }
   },
   "adminAi": {
     "breadcrumbAdmin": "Admin",
@@ -440,13 +578,14 @@
     "ctaReview": "Review"
   },
   "bookmarks": {
-    "title": "My bookmarks",
-    "kicker": "Bookmarks",
-    "description": "All your bookmarks, grouped by course.",
-    "empty": "No bookmark yet. Tap the bookmark icon while reading a course.",
+    "title": "My saved courses",
+    "kicker": "Saved course",
+    "description": "The courses you saved to find them again later.",
+    "empty": "No saved course yet. Open a course and click \"Save course\".",
     "viewBlock": "Open in course",
     "remove": "Remove",
-    "bookmarksCount": "{count, plural, one {# bookmark} other {# bookmarks}}"
+    "bookmarksCount": "{count, plural, one {# bookmark} other {# bookmarks}}",
+    "open": "Open course"
   },
   "dash": {
     "title": "My progress",
@@ -622,6 +761,52 @@
       "save": "Save",
       "cancel": "Cancel",
       "saved": "Saved"
+    },
+    "groups": {
+      "kicker": "Group management",
+      "title": "Groups",
+      "description": "Create and manage your classes. Add students via invitation codes.",
+      "newGroup": "Create a group",
+      "empty": "No groups yet.",
+      "members": "Members",
+      "curriculum": "Courses",
+      "invitations": "Invitations",
+      "deleteConfirm": "Permanently delete this group?",
+      "deleteBtn": "Delete",
+      "deleteError": "Failed to delete the group.",
+      "dateSince": "Since {date}",
+      "dateUntil": "Until {date}",
+      "form": {
+        "title": "Create a group",
+        "name": "Group name",
+        "namePlaceholder": "e.g. Year 9 class",
+        "slug": "Identifier (slug)",
+        "slugPlaceholder": "e.g. year-9-class",
+        "slugHelper": "Leave blank to auto-generate",
+        "startsAt": "Start date",
+        "endsAt": "End date",
+        "create": "Create",
+        "cancel": "Cancel",
+        "error": "Something went wrong."
+      },
+      "hub": {
+        "kicker": "Group · {name}",
+        "membersDesc": "Manage members and their roles in this group",
+        "curriculumDesc": "Assign courses accessible to this group",
+        "invitationsTitle": "Invitation codes",
+        "invitationsDesc": "Generate codes so users can join this group",
+        "newInvitation": "Generate a code",
+        "invitationFormMaxUses": "Max uses",
+        "invitationFormExpiresAt": "Expiry date (optional)",
+        "invitationFormCreate": "Generate",
+        "code": "Code",
+        "uses": "{used}/{max} uses",
+        "expires": "Expires {date}",
+        "noExpiry": "No expiry",
+        "noInvitations": "No active codes.",
+        "copyCode": "Copy",
+        "createError": "Failed to create the code."
+      }
     }
   }
 }

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -8,7 +8,8 @@
     "catalog": "Catalogue",
     "myCourses": "Mes cours",
     "teach": "Enseigner",
-    "admin": "Admin"
+    "admin": "Admin",
+    "groups": "Groupes"
   },
   "footer": {
     "rights": "© {year} · Tous droits réservés",
@@ -294,13 +295,150 @@
   "adminSettings": {
     "kicker": "ADMIN · PARAMÈTRES",
     "title": "Paramètres",
-    "description": "Réglages de l'instance, modifiables par les administrateurs.",
+    "description": "Branding, thème et réglages de l'instance, modifiables par les administrateurs.",
     "courseBuilderSection": "Course Builder",
     "maxBlocksLabel": "Nombre max de blocs par page",
     "maxBlocksHelper": "Entre {min} et {max}. Limite le nombre de blocs autorisés par page de cours.",
     "maxBlocksRange": "La valeur doit être un entier entre {min} et {max}.",
     "save": "Enregistrer",
-    "saved": "✓ Enregistré"
+    "saved": "Modifications enregistrées",
+    "saving": "Enregistrement…",
+    "discard": "Annuler",
+    "unsaved": "Modifications non enregistrées",
+    "resetSection": "Réinitialiser la section",
+    "nav": {
+      "identity": "Identité",
+      "theme": "Thème",
+      "hero": "Accueil & SEO",
+      "access": "Accès",
+      "media": "Médias",
+      "ai": "IA"
+    },
+    "sectionDescription": {
+      "identity": "Nom, logo, couleur d'accent et police de l'instance.",
+      "theme": "Palette de couleurs pour les modes clair et sombre.",
+      "hero": "Texte de la page d'accueil et métadonnées de référencement.",
+      "access": "Règles d'accès et d'inscription à la plateforme.",
+      "media": "Quotas de stockage des fichiers téléversés.",
+      "ai": "Connexion au fournisseur d'IA pour la génération de cours."
+    },
+    "preview": {
+      "title": "Aperçu en direct",
+      "themeSwitch": "Mode d'aperçu",
+      "light": "Clair",
+      "dark": "Sombre",
+      "heroFallback": "Apprenez, créez, partagez.",
+      "ctaFallback": "Commencer"
+    },
+    "identity": {
+      "name": "Nom de l'instance",
+      "tagline": "Slogan",
+      "logo": "Logo",
+      "logoHelper": "Symbole affiché à côté du nom.",
+      "logoPreset": {
+        "star": "Étoile",
+        "alpha": "Alpha",
+        "flame": "Flamme",
+        "hash": "Dièse"
+      },
+      "locale": "Langue par défaut",
+      "localeOption": {
+        "en": "Anglais",
+        "fr": "Français"
+      },
+      "accent": "Couleur d'accent",
+      "accentHelper": "Couleur principale des boutons et liens.",
+      "font": "Police",
+      "fontHelper": "Paire de polices (titres · texte).",
+      "logoMode": {
+        "preset": "Preset",
+        "image": "Image"
+      },
+      "logoUpload": "Téléverser une image",
+      "logoReplace": "Remplacer l'image",
+      "uploadError": "Échec du téléversement"
+    },
+    "theme": {
+      "modeSwitch": "Mode édité",
+      "light": "Clair",
+      "dark": "Sombre",
+      "reset": "Réinitialiser",
+      "group": {
+        "backgrounds": "Arrière-plans",
+        "text": "Texte",
+        "status": "États"
+      },
+      "token": {
+        "bgBase": "Fond principal",
+        "bgMesh1": "Halo 1",
+        "bgMesh2": "Halo 2",
+        "bgMesh3": "Halo 3",
+        "text": "Texte",
+        "textSoft": "Texte adouci",
+        "muted": "Texte discret",
+        "success": "Succès",
+        "warning": "Avertissement",
+        "danger": "Danger",
+        "green": "Vert",
+        "tip": "Astuce"
+      },
+      "tokenDesc": {
+        "bgBase": "Couleur de fond principale des pages.",
+        "bgMesh1": "Halo de dégradé en arrière-plan.",
+        "bgMesh2": "Deuxième halo de dégradé.",
+        "bgMesh3": "Troisième halo de dégradé.",
+        "text": "Couleur du texte principal.",
+        "textSoft": "Texte secondaire, moins contrasté.",
+        "muted": "Texte discret (légendes, aides).",
+        "success": "Messages de succès et validations.",
+        "warning": "Avertissements et alertes légères.",
+        "danger": "Erreurs et actions destructrices.",
+        "green": "Accent vert (progression, réussite).",
+        "tip": "Astuces et encadrés d'information."
+      }
+    },
+    "hero": {
+      "heroGroup": "Page d'accueil",
+      "heroTitle": "Titre principal",
+      "heroTitleHelper": "Laissez vide pour utiliser le texte par défaut.",
+      "heroSubtitle": "Sous-titre",
+      "heroCta": "Bouton d'action",
+      "seoGroup": "Référencement (SEO)",
+      "metaTitle": "Titre de la page",
+      "metaTitleHelper": "Idéalement moins de 60 caractères.",
+      "metaDescription": "Méta-description",
+      "metaDescriptionHelper": "Idéalement moins de 160 caractères.",
+      "favicon": "Favicon",
+      "faviconHelper": "URL de l'icône affichée dans l'onglet du navigateur.",
+      "faviconUpload": "Téléverser une image",
+      "uploadError": "Échec du téléversement"
+    },
+    "access": {
+      "signupOpen": "Inscriptions ouvertes",
+      "signupOpenHelper": "Autoriser la création de compte par de nouveaux utilisateurs.",
+      "open": "Ouvertes",
+      "closed": "Fermées"
+    },
+    "media": {
+      "userQuota": "Quota par utilisateur",
+      "userQuotaHelper": "Stockage maximum par utilisateur.",
+      "instanceQuota": "Quota de l'instance",
+      "instanceQuotaHelper": "Stockage maximum cumulé pour l'instance."
+    },
+    "ai": {
+      "apiUrl": "URL de l'API",
+      "model": "Modèle",
+      "apiKey": "Clé API",
+      "apiKeyHelper": "Laissez vide pour conserver la clé existante.",
+      "keyConfigured": "Configurée",
+      "keyMissing": "Aucune clé",
+      "keyPlaceholder": "Collez votre clé API",
+      "keyPlaceholderSet": "•••••••••• (remplacer)",
+      "temperature": "Température",
+      "temperatureHelper": "Créativité des réponses (0 = strict, 2 = créatif).",
+      "maxTokens": "Tokens max",
+      "maxTokensHelper": "Longueur maximale des réponses générées."
+    }
   },
   "adminAi": {
     "breadcrumbAdmin": "Admin",
@@ -440,13 +578,14 @@
     "ctaReview": "Revoir"
   },
   "bookmarks": {
-    "title": "Mes favoris",
-    "kicker": "Favoris",
-    "description": "Tous vos marque-pages, groupés par cours.",
-    "empty": "Aucun favori pour l'instant. Cliquez sur l'icône favori dans le lecteur d'un cours.",
-    "viewBlock": "Voir dans le cours",
+    "title": "Mes cours enregistrés",
+    "kicker": "Cours enregistré",
+    "description": "Les cours que vous avez enregistrés pour les retrouver plus tard.",
+    "empty": "Aucun cours enregistré pour l'instant. Ouvrez un cours et cliquez sur « Enregistrer le cours ».",
+    "viewBlock": "Ouvrir dans le cours",
     "remove": "Retirer",
-    "bookmarksCount": "{count, plural, one {# favori} other {# favoris}}"
+    "bookmarksCount": "{count, plural, one {# cours enregistré} other {# cours enregistrés}}",
+    "open": "Ouvrir le cours"
   },
   "dash": {
     "title": "Mes progrès",
@@ -622,6 +761,52 @@
       "save": "Enregistrer",
       "cancel": "Annuler",
       "saved": "Enregistré"
+    },
+    "groups": {
+      "kicker": "Gestion des groupes",
+      "title": "Groupes",
+      "description": "Créez et gérez vos classes. Ajoutez des élèves via des codes d'invitation.",
+      "newGroup": "Créer un groupe",
+      "empty": "Aucun groupe pour l'instant.",
+      "members": "Membres",
+      "curriculum": "Cours",
+      "invitations": "Invitations",
+      "deleteConfirm": "Supprimer ce groupe définitivement ?",
+      "deleteBtn": "Supprimer",
+      "deleteError": "Erreur lors de la suppression.",
+      "dateSince": "Depuis {date}",
+      "dateUntil": "Jusqu'au {date}",
+      "form": {
+        "title": "Créer un groupe",
+        "name": "Nom du groupe",
+        "namePlaceholder": "ex. Classe de 3ème",
+        "slug": "Identifiant (slug)",
+        "slugPlaceholder": "ex. classe-3eme",
+        "slugHelper": "Laissez vide pour générer automatiquement",
+        "startsAt": "Date de début",
+        "endsAt": "Date de fin",
+        "create": "Créer",
+        "cancel": "Annuler",
+        "error": "Une erreur est survenue."
+      },
+      "hub": {
+        "kicker": "Groupe · {name}",
+        "membersDesc": "Gérer les membres et leurs rôles dans ce groupe",
+        "curriculumDesc": "Assigner des cours accessibles à ce groupe",
+        "invitationsTitle": "Codes d'invitation",
+        "invitationsDesc": "Générez des codes pour inviter des utilisateurs à rejoindre ce groupe",
+        "newInvitation": "Générer un code",
+        "invitationFormMaxUses": "Utilisations maximum",
+        "invitationFormExpiresAt": "Date d'expiration (optionnel)",
+        "invitationFormCreate": "Générer",
+        "code": "Code",
+        "uses": "{used}/{max} utilisations",
+        "expires": "Expire le {date}",
+        "noExpiry": "Pas d'expiration",
+        "noInvitations": "Aucun code actif.",
+        "copyCode": "Copier",
+        "createError": "Erreur lors de la création."
+      }
     }
   }
 }


### PR DESCRIPTION
## Résumé

Ajoute deux fonctionnalités d'administration côté frontend, en s'appuyant sur
le backend existant :

1. Un **éditeur de paramètres & de branding** complet (le backend branding
   existait déjà mais n'était pas exploité par le front).
2. La **gestion des groupes manquante** : liste, création, invitations et hub
   (le front ne permettait ni de lister, ni de créer un groupe, ni de gérer
   les codes d'invitation).

Aucune modification backend. Purement additif : le réglage `maxBlocksPerPage`
du Course Builder existant est préservé.

##  Paramètres & branding

- Éditeur par sections : **Identité** (nom, logo image/preset, accent, police,
  langue), **Thème** (tokens de couleurs clair/sombre, reset par section,
  descriptions de chaque couleur), **Accueil & SEO** (hero, meta, favicon),
  **Accès** (inscriptions), **Médias** (quotas), **IA** (fournisseur, clé).
- Barre d'enregistrement avec suivi des changements par section.
- **Application du branding au layout racine** : injection des tokens de thème
  + favicon dynamique (avant, seul l'accent était appliqué).
- Le logo image s'affiche désormais partout (barre de navigation, pied de page).

## Groupes

- **Page liste** des groupes (grille de cartes) + **hub** par groupe.
- **Création de groupe** (modale) et **panneau d'invitations** (génération de
  codes, insertion optimiste).
- Server actions `createGroup` / `updateGroup` / `createInvitation`.
- Lien **Groupes** dans la barre de navigation (TEACHER+).


